### PR TITLE
Build WW processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,16 +34,13 @@ LINK_LIBRARIES( ${ROOT_LIBRARIES} )
 ADD_DEFINITIONS( ${ROOT_DEFINITIONS} )
 
 # Custom libraries
+set(MarlinHelp_dir /afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/SampleProduction/MarlinAnalysis/MarlinHelp)
 find_library( 
   MarlinHelp MarlinHelp 
-  HINTS 
-    /afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/SampleProduction/MarlinAnalysis/MarlinHelp/lib
+  HINTS ${MarlinHelp_dir}/lib/MarlinHelp
   REQUIRED 
 )
-get_filename_component(MarlinHelp_lib_dir ${MarlinHelp} DIRECTORY)
-include_directories(
-  ${MarlinHelp_lib_dir}/../source/MarlinHelp/include
-)
+include_directories(${MarlinHelp_dir}/include)
 
 # Compile you project
 ADD_SUBDIRECTORY( source )

--- a/macros/load_env.sh
+++ b/macros/load_env.sh
@@ -16,3 +16,6 @@ elif [ ! -z "${ILCSOFT}" ]; then
 else 
   source ${ilcsoft_dir}/init_ilcsoft.sh
 fi
+
+# Add the MarlinHelp package path
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/SampleProduction/MarlinAnalysis/MarlinHelp/lib

--- a/scripts/WWProcessorTest.xml
+++ b/scripts/WWProcessorTest.xml
@@ -7,9 +7,9 @@
   
   <global>
     <!-- Change the input file here or by command line -->
-    <parameter name="LCIOInputFiles"> /pnfs/desy.de/ilc/user/b/berggren/mc-opt.dsk/generated/250-SetA/4f/E250-SetA.P4f_ww_sl.Gwhizard-2_8_0.eL.pR.I400030.0.slcio </parameter>
+    <parameter name="LCIOInputFiles"> /nfs/dust/ilc/user/skawada/mini-DST/massSGVprod/sgvdst8/SGV-mini-DST-E250-SetA.P4f_ww_sl.Gwhizard-2_8_4.eL.pR.I500078_SGVDST.0.slcio </parameter>
     <!-- The maximum number of events + runs to process -->
-    <parameter name="MaxRecordNumber" value="10"/>
+    <parameter name="MaxRecordNumber" value="0"/>
     <!-- The number of events to skip on start -->
     <parameter name="SkipNEvents" value="0"/>
     <parameter name="SupressCheck" value="false"/>
@@ -22,7 +22,10 @@
   <!-- Your processor configuration here after -->
   <processor name="MyWWProcessor" type="WWProcessor">
     <!-- The MC particle collection name -->
-    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticlesSkimmed </parameter>
+    <parameter name="OutputFilePath"> 
+      /nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/Test/WWtest.root
+    </parameter>
   </processor>
   
 </marlin>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories( include )
 # This compiles everything in the src directory and build a library
 # called lib%(repository)s.so, that with be install in the lib directory
 # in the top level directory of your project 
+aux_source_directory( src/Utils SRC_FILES )
 aux_source_directory( src/WW SRC_FILES )
 add_shared_library( ${PROJECT_NAME} ${SRC_FILES} )
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,8 +1,3 @@
-#######################################################
-# cmake file for building %(repository)s analysis package
-# @author Ete Remi, DESY
-#######################################################
-
 # -------------------------------------------------
 # include directories
 include_directories( include )
@@ -14,6 +9,7 @@ include_directories( include )
 # in the top level directory of your project 
 aux_source_directory( src/Utils SRC_FILES )
 aux_source_directory( src/WW SRC_FILES )
+aux_source_directory( src/WW/Processor SRC_FILES )
 add_shared_library( ${PROJECT_NAME} ${SRC_FILES} )
 
 # Link external libraries

--- a/source/include/Utils/Collections.h
+++ b/source/include/Utils/Collections.h
@@ -1,0 +1,24 @@
+#ifndef LIB_UTILS_COLLECTIONS_H
+#define LIB_UTILS_COLLECTIONS_H 1
+
+// Includes from iLCSoft
+#include "lcio.h"
+#include <EVENT/LCEvent.h>
+#include <EVENT/LCCollection.h>
+
+// Standard library
+#include <vector>
+
+namespace Utils {
+namespace Collections {
+/** LCIO helper functions related to LCCollections.
+ **/
+
+template <class T>
+std::vector<T *> read(EVENT::LCEvent *event, const std::string &name);
+
+} // namespace Collections
+} // namespace Utils
+
+#include <Utils/Collections.tpp>
+#endif

--- a/source/include/Utils/Collections.tpp
+++ b/source/include/Utils/Collections.tpp
@@ -1,0 +1,48 @@
+#ifndef LIB_UTILS_COLLECTIONS_TPP
+#define LIB_UTILS_COLLECTIONS_TPP 1
+
+#include <Utils/Collections.h>
+
+// Standard library
+#include <string>
+
+namespace Utils {
+
+//------------------------------------------------------------------------------
+
+template <class T>
+std::vector<T *> Collections::read(EVENT::LCEvent *event,
+                                  const std::string &name) {
+  /** Read the given collection into a vector of the template particle type.
+   **/
+  std::vector<T *> output{};
+
+  // Get the collection from the event
+  LCCollection *collection = event->getCollection(name);
+  streamlog_out(DEBUG) << "Number of particles in '" << name
+                       << "': " << std::to_string(collection->getNumberOfElements())
+                       << std::endl;
+
+  for (int e = 0; e < collection->getNumberOfElements(); e++) {
+    // Get an object from the collection and convert it to a particle
+    T *particle = static_cast<T *>(collection->getElementAt(e));
+
+    // If the collection type is wrong you end up with a null pointer here.
+    // Always check it !
+    if (nullptr == particle) {
+      streamlog_out(ERROR) << "Wrong object type in collection '" << name << "'"
+                           << std::endl;
+      continue;
+    }
+
+    output.push_back(particle);
+  }
+
+  return output;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Utils
+
+#endif

--- a/source/include/Utils/HeaderInfo.h
+++ b/source/include/Utils/HeaderInfo.h
@@ -1,0 +1,32 @@
+#ifndef LIB_UTILS_HEADERINFO_H
+#define LIB_UTILS_HEADERINFO_H 1
+
+// Includes from iLCSoft
+#include "lcio.h"
+#include <EVENT/LCEvent.h>
+
+// Includes from ROOT
+#include "TTree.h"
+
+namespace Utils {
+
+struct HeaderInfo {
+  /** Header class for simple extraction of LCIO event header info (in ILD 
+      convention: particle1 = e-, particle2 = e+).
+   **/
+  
+  int m_process_ID {};
+  double m_energy {};
+  double m_weight {};
+  int m_eM_chirality {};
+  int m_eP_chirality {};
+  double m_cross_section {};
+  double m_cross_section_err {};
+  
+  void connect(TTree * tree);
+  void read(const EVENT::LCEvent & event);
+};
+
+} // namespace Utils
+
+#endif

--- a/source/include/Utils/MC.h
+++ b/source/include/Utils/MC.h
@@ -1,0 +1,21 @@
+#ifndef LIB_UTILS_MC_H
+#define LIB_UTILS_MC_H 1
+
+// Includes from ROOT
+#include "TLorentzVector.h"
+
+// Includes from iLCSoft
+#include "lcio.h"
+#include <EVENT/MCParticle.h>
+
+namespace Utils {
+namespace MC {
+/** LCIO helper functions related to MC particles.
+ **/
+
+TLorentzVector get_tlv(const lcio::MCParticle &mcp);
+
+}
+} // namespace Utils
+
+#endif

--- a/source/include/Utils/MC.h
+++ b/source/include/Utils/MC.h
@@ -6,16 +6,56 @@
 
 // Includes from iLCSoft
 #include "lcio.h"
+#include <IMPL/MCParticleImpl.h>
 #include <EVENT/MCParticle.h>
+
+// Standard library
+#include <vector>
 
 namespace Utils {
 namespace MC {
 /** LCIO helper functions related to MC particles.
  **/
 
-TLorentzVector get_tlv(const lcio::MCParticle &mcp);
+// --- Observable related ------------------------------------------------------
+TLorentzVector get_tlv(const EVENT::MCParticle &mcp);
+bool fits_id(const EVENT::MCParticle &mcp, const std::vector<int> &pdg_ids);
+bool is_type(const EVENT::MCParticle &mcp, const std::vector<int> &ids_plus,
+             const std::vector<int> &ids_minus, int sign = 0);
+bool is_e(const EVENT::MCParticle &mcp, int charge = 0);
+bool is_mu(const EVENT::MCParticle &mcp, int charge = 0);
+bool is_tau(const EVENT::MCParticle &mcp, int charge = 0);
+bool is_nu_e(const EVENT::MCParticle &mcp, int sign = 0);
+bool is_nu_mu(const EVENT::MCParticle &mcp, int sign = 0);
+bool is_nu_tau(const EVENT::MCParticle &mcp, int sign = 0);
+bool is_uptype(const EVENT::MCParticle &mcp, int sign = 0);
+bool is_downtype(const EVENT::MCParticle &mcp, int sign = 0);
+bool is_W_compatible(const EVENT::MCParticle &mcp1,
+                     const EVENT::MCParticle &mcp2, int charge = 0);
+// -----------------------------------------------------------------------------
 
-}
+// --- Vector related ----------------------------------------------------------
+EVENT::MCParticle *find_first(const EVENT::MCParticleVec &vec,
+                              std::vector<int> pdg_ids, int skip = 0,
+                              int end = -1);
+EVENT::MCParticle *find_first_lepton(const EVENT::MCParticleVec &vec,
+                                     int skip = 0, int end = -1);
+EVENT::MCParticle *find_first_W(const EVENT::MCParticleVec &vec,
+                                int charge = 0);
+// -----------------------------------------------------------------------------
+
+// --- Elements according to ILD conventions -----------------------------------
+IMPL::MCParticleImpl determine_W(const EVENT::MCParticleVec &vec, int charge);
+EVENT::MCParticle *incoming_eM_after_ISR(const EVENT::MCParticleVec &vec);
+EVENT::MCParticle *incoming_eP_after_ISR(const EVENT::MCParticleVec &vec);
+// -----------------------------------------------------------------------------
+
+// --- Create MCParticles ------------------------------------------------------
+IMPL::MCParticleImpl create_W(const EVENT::MCParticle &mcp1,
+                           const EVENT::MCParticle &mcp2);
+// -----------------------------------------------------------------------------
+
+} // namespace MC
 } // namespace Utils
 
 #endif

--- a/source/include/WW/WWObservables.h
+++ b/source/include/WW/WWObservables.h
@@ -1,0 +1,42 @@
+#ifndef LIB_WW_WWOBSERVABLES_H
+#define LIB_WW_WWOBSERVABLES_H 1
+
+namespace WW {
+  
+struct WWObservables {
+  /** Helper struct to keep all the variables that will be connected with the TTree branches in the WW analysis.
+   **/
+  
+  // Boost-independent observables
+  bool decay_to_mu {};
+  bool decay_to_tau {};
+  int l_charge {};
+  
+  // Observables in the leptonic W rest frame
+  // -> z axis should be along W flight direction
+  double phi_l_star {};
+  double costh_l_star {};
+  
+  // Observables in the WW rest frame
+  // -> Detector coordinate system (expecting no significant x-y boost)
+  double costh_Wminus_star {};
+  
+  // Observables in detector rest frame
+  double costh_l {};
+  
+  void reset() {
+    /** Reset all observables to their default value.
+     **/
+    decay_to_mu = false;
+    decay_to_tau = false;
+    l_charge = 0;
+    phi_l_star = 9e9;
+    costh_l_star = 9e9;
+    costh_Wminus_star = 9e9;
+    costh_l = 9e9;
+  }
+};
+  
+} // namespace WW
+
+#endif

--- a/source/include/WW/WWProcessor.h
+++ b/source/include/WW/WWProcessor.h
@@ -1,7 +1,16 @@
 #ifndef LIB_WWPROCESSOR_H
 #define LIB_WWPROCESSOR_H 1
 
+#include <Utils/HeaderInfo.h>
+#include <WW/WWObservables.h>
 #include "marlin/Processor.h"
+
+// Includes from ROOT
+#include <TFile.h>
+#include <TTree.h>
+
+// Standard library
+#include <memory>
 
 class WWProcessor : public marlin::Processor {
 public:
@@ -64,6 +73,20 @@ private:
   std::string m_mcCollectionName = {""};
   std::string m_file_path{""};
   std::string m_tree_name{""};
+
+  // ---------------------------------------------------------------------------
+
+  // TFile and TTree with result output
+  std::unique_ptr<TFile> m_file{};
+  TTree *m_tree{}; // Needs to be pure pointer, belongs to file
+  
+  // Output information
+  Utils::HeaderInfo m_header {};
+  WW::WWObservables m_observables{};
+
+  // Internal functions
+  void create_tree();
+  void save_tree();
 };
 
 #endif

--- a/source/include/WW/WWProcessor.h
+++ b/source/include/WW/WWProcessor.h
@@ -60,8 +60,10 @@ private:
   // Initialize your members in the class definition to
   // be more efficient and avoid compiler warnings
 
-  /// The reconstructed particle collection name
+  // --- Input parameters ------------------------------------------------------
   std::string m_mcCollectionName = {""};
+  std::string m_file_path{""};
+  std::string m_tree_name{""};
 };
 
 #endif

--- a/source/include/WW/WWProcessor.h
+++ b/source/include/WW/WWProcessor.h
@@ -3,6 +3,9 @@
 
 #include <Utils/HeaderInfo.h>
 #include <WW/WWObservables.h>
+
+// Includes from iLCSoft
+#include "EVENT/MCParticle.h"
 #include "marlin/Processor.h"
 
 // Includes from ROOT
@@ -87,6 +90,12 @@ private:
   // Internal functions
   void create_tree();
   void save_tree();
+
+  void extract_observables(const EVENT::MCParticleVec &mcps);
+  void extract_lab_observables(const EVENT::MCParticle &l);
+  void extract_ee_observables(const EVENT::MCParticle &Wminus);
+  void extract_Wl_observables(const EVENT::MCParticle &Wl,
+                              const EVENT::MCParticle &l);
 };
 
 #endif

--- a/source/src/Utils/HeaderInfo.cpp
+++ b/source/src/Utils/HeaderInfo.cpp
@@ -1,0 +1,37 @@
+#include <Utils/HeaderInfo.h>
+
+namespace Utils {
+
+//------------------------------------------------------------------------------
+
+void HeaderInfo::connect(TTree *tree) {
+  /** Create all the needed branches in the given TTree and connect them the
+   *member variables of this HeaderInfo.
+   **/
+  tree->Branch("process_ID", &m_process_ID, "process_ID/I");
+  tree->Branch("energy", &m_energy, "energy/D");
+  tree->Branch("weight", &m_weight, "weight/D");
+  tree->Branch("eM_chirality", &m_eM_chirality, "eM_chirality/I");
+  tree->Branch("eP_chirality", &m_eP_chirality, "eP_chirality/I");
+  tree->Branch("cross_section", &m_cross_section, "cross_section/D");
+  tree->Branch("cross_section_err", &m_cross_section_err,
+               "cross_section_err/D");
+}
+
+//------------------------------------------------------------------------------
+
+void HeaderInfo::read(const EVENT::LCEvent &event) {
+  /** Read the information from a given event.
+   **/
+  m_process_ID = event.getParameters().getIntVal("ProcessID");
+  m_energy = event.getParameters().getFloatVal("Energy");
+  m_weight = event.getParameters().getFloatVal("_weight");
+  m_eM_chirality = event.getParameters().getFloatVal("beamPol1");
+  m_eP_chirality = event.getParameters().getFloatVal("beamPol2");
+  m_cross_section = event.getParameters().getFloatVal("crossSection");
+  m_cross_section_err = event.getParameters().getFloatVal("crossSectionError");
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Utils

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -1,0 +1,15 @@
+#include <Utils/MC.h>
+
+namespace Utils {
+  
+//------------------------------------------------------------------------------
+
+TLorentzVector MC::get_tlv(const lcio::MCParticle &mcp) {
+  /** Return the four-momentum of the MC particle as a TLorentzVector.
+   **/
+  return TLorentzVector( mcp.getMomentum(), mcp.getEnergy() );
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Utils

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -1,13 +1,367 @@
 #include <Utils/MC.h>
 
+// Includes from iLCSoft
+#include "streamlog/streamlog.h"
+
+// Standard library
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
 namespace Utils {
-  
+
 //------------------------------------------------------------------------------
 
 TLorentzVector MC::get_tlv(const lcio::MCParticle &mcp) {
   /** Return the four-momentum of the MC particle as a TLorentzVector.
    **/
-  return TLorentzVector( mcp.getMomentum(), mcp.getEnergy() );
+  return TLorentzVector(mcp.getMomentum(), mcp.getEnergy());
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::fits_id(const EVENT::MCParticle &mcp,
+                 const std::vector<int> &pdg_ids) {
+  /** Check if the particle fits any of the given IDs;
+   **/
+  auto mcp_id = mcp.getPDG();
+  bool fits = false;
+  for (int id : pdg_ids) {
+    if (mcp_id == id) {
+      fits = true;
+      break;
+    }
+  }
+  return fits;
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::is_type(const EVENT::MCParticle &mcp, const std::vector<int> &ids_plus,
+                 const std::vector<int> &ids_minus, int sign) {
+  /** Check if the given particle is of a type.
+      The type has a plus and a minus sign option (sign can be charge or
+   particle/antiparticle). If sign not specified than either one is checked.
+   **/
+  std::vector<int> ids{};
+  if ((sign == 0) || (sign == 1)) {
+    ids.insert(ids.end(), ids_plus.begin(), ids_plus.end());
+  } else if ((sign == 0) || (sign == -1)) {
+    ids.insert(ids.end(), ids_minus.begin(), ids_minus.end());
+  } else {
+    throw std::invalid_argument("Looking for invalid sign: " +
+                                std::to_string(sign));
+  }
+
+  return MC::fits_id(mcp, ids);
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::is_e(const EVENT::MCParticle &mcp, int charge) {
+  /** Check if the particle is an electron/positron.
+      Charge can be specified, if not (0) either is considered.
+   **/
+  return MC::is_type(mcp, {-11}, {11}, charge);
+}
+bool MC::is_mu(const EVENT::MCParticle &mcp, int charge) {
+  /** Check if the particle is a muon/anti-muon.
+      Charge can be specified, if not (0) either is considered.
+   **/
+  return MC::is_type(mcp, {-13}, {13}, charge);
+}
+bool MC::is_tau(const EVENT::MCParticle &mcp, int charge) {
+  /** Check if the particle is a tau/anti-tau.
+      Charge can be specified, if not (0) either is considered.
+   **/
+  return MC::is_type(mcp, {-15}, {15}, charge);
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::is_nu_e(const EVENT::MCParticle &mcp, int sign) {
+  /** Check if the particle is an electron/positron.
+      Sign can be specified, if not (0) either is considered.
+      Sign: +1 particle, -1 antiparticle (NOTE: opposite to charge leptons!)
+   **/
+  return MC::is_type(mcp, {12}, {-12}, sign);
+}
+bool MC::is_nu_mu(const EVENT::MCParticle &mcp, int sign) {
+  /** Check if the particle is a muon/anti-muon.
+      Sign can be specified, if not (0) either is considered.
+      Sign: +1 particle, -1 antiparticle (NOTE: opposite to charge leptons!)
+   **/
+  return MC::is_type(mcp, {14}, {-14}, sign);
+}
+bool MC::is_nu_tau(const EVENT::MCParticle &mcp, int sign) {
+  /** Check if the particle is a tau/anti-tau.
+      Sign can be specified, if not (0) either is considered.
+      Sign: +1 particle, -1 antiparticle (NOTE: opposite to charge leptons!)
+   **/
+  return MC::is_type(mcp, {16}, {-16}, sign);
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::is_uptype(const EVENT::MCParticle &mcp, int sign) {
+  /** Check if the quark is uptype.
+      If sign given, then quark (+1) or antiquark (-1) is searched for.
+   **/
+  return MC::is_type(mcp, {2, 4, 6}, {-2, -4, -6}, sign);
+}
+
+bool MC::is_downtype(const EVENT::MCParticle &mcp, int sign) {
+  /** Check if the quark is downtype.
+      If sign given, then quark (+1) or antiquark (-1) is searched for.
+   **/
+  return MC::is_type(mcp, {1, 3, 5}, {-1, -3, -5}, sign);
+}
+
+//------------------------------------------------------------------------------
+
+bool MC::is_W_compatible(const EVENT::MCParticle &mcp1,
+                         const EVENT::MCParticle &mcp2, int charge) {
+  /** Check if the two given MC particles are potentially decay products of a
+   charged W. The charge of the W can be given, if set to 0 the charge won't be
+   checked.
+   **/
+  bool fits = false;
+
+  if (mcp1.getPDG() * mcp2.getPDG() > 0) {
+    // Not a particle antiparticle pair, definitely not a W
+    streamlog_out(DEBUG) << "Pair not charge compatible with W." << std::endl;
+    fits = false;
+  } else if (charge == 1) {
+    fits =
+        // Is it qqbar?
+        (MC::is_uptype(mcp1, +1) && MC::is_downtype(mcp2, -1)) ||
+        (MC::is_uptype(mcp2, +1) && MC::is_downtype(mcp1, -1)) ||
+        // Is it l-nu pair?
+        (MC::is_e(mcp1, +1) && MC::is_nu_e(mcp2, +1)) ||
+        (MC::is_e(mcp2, +1) && MC::is_nu_e(mcp1, +1)) ||
+        (MC::is_mu(mcp1, +1) && MC::is_nu_mu(mcp2, +1)) ||
+        (MC::is_mu(mcp2, +1) && MC::is_nu_mu(mcp1, +1)) ||
+        (MC::is_tau(mcp1, +1) && MC::is_nu_tau(mcp2, +1)) ||
+        (MC::is_tau(mcp2, +1) && MC::is_nu_tau(mcp1, +1));
+    if (!fits) {
+      streamlog_out(DEBUG) << "Pair not W+ compatible." << std::endl;
+    } else {
+      streamlog_out(DEBUG) << "Pair W+ compatible." << std::endl;
+    }
+  } else if (charge == -1) {
+    fits =
+        // Is it qqbar?
+        (MC::is_uptype(mcp1, -1) && MC::is_downtype(mcp2, +1)) ||
+        (MC::is_uptype(mcp2, -1) && MC::is_downtype(mcp1, +1)) ||
+        // Is it l-nu pair?
+        (MC::is_e(mcp1, -1) && MC::is_nu_e(mcp2, -1)) ||
+        (MC::is_e(mcp2, -1) && MC::is_nu_e(mcp1, -1)) ||
+        (MC::is_mu(mcp1, -1) && MC::is_nu_mu(mcp2, -1)) ||
+        (MC::is_mu(mcp2, -1) && MC::is_nu_mu(mcp1, -1)) ||
+        (MC::is_tau(mcp1, -1) && MC::is_nu_tau(mcp2, -1)) ||
+        (MC::is_tau(mcp2, -1) && MC::is_nu_tau(mcp1, -1));
+    if (!fits) {
+      streamlog_out(DEBUG) << "Pair not W- compatible." << std::endl;
+    } else {
+      streamlog_out(DEBUG) << "Pair W- compatible." << std::endl;
+    }
+  } else if (charge == 0) {
+    // Look for either one
+    fits = MC::is_W_compatible(mcp1, mcp2, 1) ||
+           MC::is_W_compatible(mcp1, mcp2, -1);
+  } else {
+    throw std::invalid_argument("Unknown W charge: " + std::to_string(charge));
+  }
+
+  return fits;
+}
+
+//------------------------------------------------------------------------------
+
+EVENT::MCParticle *MC::find_first(const EVENT::MCParticleVec &vec,
+                                  std::vector<int> pdg_ids, int skip, int end) {
+  /** Return the first particle in the vector that fits any of the given IDs.
+      Optional:
+       - Skip the first N elements of the vector (e.g. to skip initial
+   particles).
+       - End search at given particle (give index!, -1 means whole vector)
+   **/
+
+  // Lambda that checks if any ID fits for a given particle
+  auto id_lambda = [pdg_ids](EVENT::MCParticle *mcp) {
+    return fits_id(*mcp, pdg_ids);
+  };
+
+  // Check that we're not skipping past the last vector element
+  int n_mcps = int(vec.size());
+  if (skip >= n_mcps) {
+    throw std::out_of_range("Trying to skip past vector end.");
+  }
+
+  // Check if given end point is valid
+  if (!((end == -1) || ((end > skip) && (end < n_mcps)))) {
+    throw std::out_of_range("Invalid end point " + std::to_string(end));
+  }
+
+  // Choose a valid endpoint for search
+  auto end_ptr = std::end(vec);
+  if (end != -1) {
+    end_ptr = std::begin(vec) + end + 1;
+  }
+
+  // Try to find the first element
+  auto iterator = std::find_if(std::begin(vec) + skip, end_ptr, id_lambda);
+
+  // If element not in vector return a null pointer
+  if (iterator == end_ptr) {
+    streamlog_out(DEBUG) << "Couldn't find any fitting particle in MC vector: ";
+    for (int id : pdg_ids)
+      streamlog_out(DEBUG) << std::to_string(id) << " ";
+    streamlog_out(DEBUG) << std::endl;
+    return NULL;
+  }
+
+  return *iterator;
+}
+
+//------------------------------------------------------------------------------
+
+EVENT::MCParticle *MC::find_first_lepton(const EVENT::MCParticleVec &vec,
+                                         int skip, int end) {
+  /** Return the first lepton in the vector that fits any of the given IDs.
+      Optional:
+       - Skip the first N elements of the vector (e.g. to skip initial
+   particles).
+       - End search at given particle (-1 means whole vector)
+   **/
+  auto lepton_ids = {11, -11, 13, -13, 15, -15};
+  return MC::find_first(vec, lepton_ids, skip, end);
+}
+
+//------------------------------------------------------------------------------
+
+EVENT::MCParticle *MC::find_first_W(const EVENT::MCParticleVec &vec,
+                                    int charge) {
+  /** Return the first W in the vector. If charge not specified (0) the first is
+   *given independent of charge.
+   **/
+  std::vector<int> ids{};
+
+  // Which W are we looking for
+  if (charge == 0) {
+    ids = {24, -24};
+  } else if (charge == 1) {
+    ids = {24};
+  } else if (charge == -1) {
+    ids = {-24};
+  } else {
+    throw std::invalid_argument("Looking for invalid W charge: " +
+                                std::to_string(charge));
+  }
+
+  return MC::find_first(vec, ids);
+}
+
+//------------------------------------------------------------------------------
+
+IMPL::MCParticleImpl MC::determine_W(const EVENT::MCParticleVec &vec,
+                                     int charge) {
+  /** Determine the W of the given charge (in a semileptonic 4-fermion process)
+   using the ILD convention for the MCParticle list:
+        - Look for qq pair or lnu pair that works with W hypothesis
+   **/
+  // First check if a valid charge is given
+  if (std::abs(charge) != 1) {
+    throw std::invalid_argument("Invalid W charge: " + std::to_string(charge));
+  }
+
+  // look for q/qbar pair or l/nu pair (should be indices 8-13 (11 if no
+  // explicit Ws))
+  auto q1 = MC::find_first(vec, {1, 2, 3, 4, 5}, 8, 13);
+  auto q2 = MC::find_first(vec, {-1, -2, -3, -4, -5}, 8, 13);
+
+  auto l = MC::find_first(vec, {11, 13, 15, -11, -13, -15}, 8, 13);
+  auto nu = MC::find_first(vec, {12, 14, 16, -12, -14, -16}, 8, 13);
+
+  // Check if any are compatible
+  bool q_compatible = false;
+  bool l_compatible = false;
+  if (q1 != NULL && q2 != NULL) {
+    q_compatible = MC::is_W_compatible(*q1, *q2, charge);
+  }
+  if (l != NULL && nu != NULL) {
+    l_compatible = MC::is_W_compatible(*l, *nu, charge);
+  }
+
+  // There should never be a case when both are compatible
+  if (q_compatible && l_compatible) {
+    throw std::domain_error("Both l and q compatible W found!");
+  } else if ((!q_compatible) && (!l_compatible)) {
+    throw std::domain_error("No compatible W found!");
+  }
+
+  IMPL::MCParticleImpl res_W;
+
+  // Create a W from the correct pair
+  if (q_compatible) {
+    res_W = MC::create_W(*q1, *q2);
+  } else if (l_compatible) {
+    res_W = MC::create_W(*l, *nu);
+  }
+
+  return res_W;
+}
+
+//------------------------------------------------------------------------------
+
+EVENT::MCParticle *MC::incoming_eM_after_ISR(const EVENT::MCParticleVec &vec) {
+  /** Return the incoming electron after ISR.
+      ILD convention: First four elements in collection are before ISR
+   **/
+  return MC::find_first(vec, {11}, 4);
+}
+
+EVENT::MCParticle *MC::incoming_eP_after_ISR(const EVENT::MCParticleVec &vec) {
+  /** Return the incoming positron after ISR.
+      ILD convention: First four elements in collection are before ISR
+   **/
+  return MC::find_first(vec, {-11}, 4);
+}
+
+//------------------------------------------------------------------------------
+
+IMPL::MCParticleImpl MC::create_W(const EVENT::MCParticle &mcp1,
+                                  const EVENT::MCParticle &mcp2) {
+  /** Create a W MCParticle from the given two particles.
+   **/
+  // First check if the particles are W-compatible.
+  if (!MC::is_W_compatible(mcp1, mcp2)) {
+    throw std::invalid_argument("The particles are not W compatible!");
+  }
+
+  IMPL::MCParticleImpl W_res;
+
+  if (MC::is_W_compatible(mcp1, mcp2, +1)) {
+    W_res.setPDG(+24);
+  } else if (MC::is_W_compatible(mcp1, mcp2, -1)) {
+    W_res.setPDG(-24);
+  }
+  auto E1 = mcp1.getEnergy();
+  auto E2 = mcp2.getEnergy();
+  auto mom1 = mcp1.getMomentum();
+  auto mom2 = mcp2.getMomentum();
+
+  auto E_W = E1 + E2;
+  double p_W[3] = {mom1[0] + mom2[0], mom1[1] + mom2[1], mom1[2] + mom2[2]};
+  auto m_W = std::sqrt(E_W * E_W -
+                       (p_W[0] * p_W[0] + p_W[1] * p_W[1] + p_W[2] * p_W[2]));
+
+  W_res.setMomentum(p_W);
+  W_res.setMass(m_W);
+  W_res.setCharge(mcp1.getCharge() + mcp2.getCharge());
+
+  return W_res;
 }
 
 //------------------------------------------------------------------------------

--- a/source/src/WW/Processor/create_tree.cpp
+++ b/source/src/WW/Processor/create_tree.cpp
@@ -1,0 +1,26 @@
+#include <WW/WWProcessor.h>
+
+void WWProcessor::create_tree() {
+  /** Open the output file, create the needed TTree, create its branches and
+      connect them to the observable variables.
+   **/
+  // Open the output file
+  m_file = std::make_unique<TFile>(m_file_path.c_str(), "recreate");
+   
+  // Create the tree
+  m_tree = new TTree(m_tree_name.c_str(), m_tree_name.c_str());
+
+  // Connect header info
+  m_header.connect(m_tree);
+
+  // Create and connect the observable branches
+  m_tree->Branch("decay_to_mu", &m_observables.decay_to_mu, "decay_to_mu/O");
+  m_tree->Branch("decay_to_tau", &m_observables.decay_to_tau, "decay_to_tau/O");
+  m_tree->Branch("l_charge", &m_observables.l_charge, "l_charge/I");
+  m_tree->Branch("phi_l_star", &m_observables.phi_l_star, "phi_l_star/D");
+  m_tree->Branch("costh_l_star", &m_observables.costh_l_star,
+                 "costh_l_star/D");
+  m_tree->Branch("costh_Wminus_star", &m_observables.costh_Wminus_star,
+                 "costh_Wminus_star/D");
+  m_tree->Branch("costh_l", &m_observables.costh_l, "costh_l/D");
+}

--- a/source/src/WW/Processor/extract_Wl_observables.cpp
+++ b/source/src/WW/Processor/extract_Wl_observables.cpp
@@ -1,0 +1,41 @@
+#include <Utils/MC.h>
+#include <WW/WWProcessor.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/ILD/Machine.h>
+#include <MarlinHelp/Root/LorentzVec.h>
+
+void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
+                                         const EVENT::MCParticle &l) {
+  /** Extract the lepton observables in the leptonically decaying W system.
+      Need angles in W rest frame and with z' axis along W_l flight direction:
+      1. Boost into e+e- system after ISR
+      2. Boost into W_l system
+      3. Rotate to be along W_l axis
+      4. Extract angles
+   **/
+  // Lorentz vectors in lab frame
+  auto l_tlv_lab = Utils::MC::get_tlv(l);
+  auto Wl_tlv_lab = Utils::MC::get_tlv(Wl);
+
+  // Lorentz vectors in e+e- frame (after removing crossing angle)
+  auto energy = m_header.m_energy;
+  auto eM_tlv_ee = TLorentzVector(0, 0, energy, energy); // e- in z direction
+  auto l_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+      l_tlv_lab, m_header.m_energy);
+  auto Wl_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+      Wl_tlv_lab, m_header.m_energy);
+
+  // Boost into the W system (boosting e- not necessary, just less confusing)
+  auto l_tlv_Wl = MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_lab, Wl_tlv_ee);
+
+  // Rotate to be along W flight direction (x in e-W plane)
+  // (Previous boost was along W direction, so e-W plane didn't change)
+  auto l_tlv_Wl_rot =
+      MarlinHelp::Root::LorentzVec::rotate_into(l_tlv_Wl, Wl_tlv_ee, eM_tlv_ee);
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_l_star = l_tlv_Wl_rot.CosTheta();
+  m_observables.phi_l_star = l_tlv_Wl_rot.Phi();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/WW/Processor/extract_ee_observables.cpp
+++ b/source/src/WW/Processor/extract_ee_observables.cpp
@@ -1,0 +1,20 @@
+#include <Utils/MC.h>
+#include <WW/WWProcessor.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/ILD/Machine.h>
+
+void WWProcessor::extract_ee_observables(const EVENT::MCParticle &Wminus) {
+  /** Extract the observables in the e+e- rest frame.
+   **/
+  // Lorentz vectors in lab frame
+  auto Wminus_tlv_lab = Utils::MC::get_tlv(Wminus);
+
+  // Lorentz vectors in e+e- frame (after removing crossing angle)
+  auto Wminus_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+      Wminus_tlv_lab, m_header.m_energy);
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_Wminus_star = Wminus_tlv_ee.CosTheta();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/WW/Processor/extract_lab_observables.cpp
+++ b/source/src/WW/Processor/extract_lab_observables.cpp
@@ -1,0 +1,16 @@
+#include <Utils/MC.h>
+#include <WW/WWProcessor.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/Root/LorentzVec.h>
+
+void WWProcessor::extract_lab_observables(const EVENT::MCParticle &l) {
+  /** Extract the observables in the lab/detector rest frame.
+   **/
+  // Lorentz vectors in lab frame
+  auto l_tlv_lab = Utils::MC::get_tlv(l);
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_l = l_tlv_lab.CosTheta();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/WW/Processor/extract_observables.cpp
+++ b/source/src/WW/Processor/extract_observables.cpp
@@ -1,0 +1,48 @@
+#include <Utils/MC.h>
+#include <WW/WWProcessor.h>
+
+void WWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
+  /** Extract the relevant generator level observables.
+   **/
+  // Find the first lepton (skip the initial e+e- and ISR -> skip 8)
+  auto l = Utils::MC::find_first_lepton(mcps, 8);
+  m_observables.l_charge = int(l->getCharge());
+
+  if (Utils::MC::is_mu(*l))
+    m_observables.decay_to_mu = true;
+  if (Utils::MC::is_tau(*l))
+    m_observables.decay_to_tau = true;
+
+  // First try to see if W's are explicitely listed in MC list
+  auto W_l = Utils::MC::find_first_W(mcps, m_observables.l_charge);
+  auto W_h = Utils::MC::find_first_W(mcps, -1 * m_observables.l_charge);
+
+  // If W's weren't explicitely found, look for their decay products
+  IMPL::MCParticleImpl W_l_tech;
+  if (W_l == NULL) {
+    W_l_tech = Utils::MC::determine_W(mcps, m_observables.l_charge);
+    W_l = &W_l_tech;
+  }
+  IMPL::MCParticleImpl W_h_tech;
+  if (W_h == NULL) {
+    W_h_tech = Utils::MC::determine_W(mcps, -1 * m_observables.l_charge);
+    W_h = &W_h_tech;
+  }
+
+  // Which one is W+, which one W-?
+  auto Wplus = W_l;
+  auto Wminus = W_h;
+  if (m_observables.l_charge == -1) {
+    Wplus = W_h;
+    Wminus = W_l;
+  }
+
+  // Extract observables in detector rest frame
+  this->extract_lab_observables(*l);
+
+  // Extract observables in ee rest frame
+  this->extract_ee_observables(*Wminus);
+
+  // Extract lepton angles in W_lep system
+  this->extract_Wl_observables(*W_l, *l);
+}

--- a/source/src/WW/Processor/save_tree.cpp
+++ b/source/src/WW/Processor/save_tree.cpp
@@ -1,0 +1,14 @@
+#include <WW/WWProcessor.h>
+
+void WWProcessor::save_tree() {
+  /** Save the output tree and close the file.
+   **/
+  m_file->cd(); // go to output file
+  
+  streamlog_out(DEBUG) << "Writing tree." << std::endl; 
+  m_tree->Write();
+  
+  streamlog_out(DEBUG) << "Closing file." << std::endl; 
+  m_file->Close();
+   
+}

--- a/source/src/WW/WWProcessor.cc
+++ b/source/src/WW/WWProcessor.cc
@@ -1,6 +1,10 @@
 // -- your process header
 #include "WW/WWProcessor.h"
 
+// Custom headers
+#include <Utils/Collections.h>
+#include <Utils/MC.h>
+
 // -- lcio headers
 #include "EVENT/LCCollection.h"
 #include "EVENT/MCParticle.h"
@@ -56,14 +60,12 @@ void WWProcessor::processEvent(EVENT::LCEvent *event) {
   streamlog_out(DEBUG) << "Processing event no " << event->getEventNumber()
                        << " - run " << event->getEventNumber() << std::endl;
 
-  // Collect MC collection
-  EVENT::LCCollection *mc_collection{};
-  try {
-    mc_collection = event->getCollection(m_mcCollectionName);
-  } catch (EVENT::DataNotAvailableException &) {
-    streamlog_out(WARNING) << "MC collection '" << m_mcCollectionName
-                           << "' is not available !" << std::endl;
+  auto mc_particles =
+      Utils::Collections::read<EVENT::MCParticle>(event, m_mcCollectionName);
+  for (const auto mcp_ptr : mc_particles) {
+    auto tlv = Utils::MC::get_tlv(*mcp_ptr);
   }
+  
 }
 
 //------------------------------------------------------------------------------

--- a/source/src/WW/WWProcessor.cc
+++ b/source/src/WW/WWProcessor.cc
@@ -71,10 +71,8 @@ void WWProcessor::processEvent(EVENT::LCEvent *event) {
   // Read the observables
   auto mcps =
       Utils::Collections::read<EVENT::MCParticle>(event, m_mcCollectionName);
-  for (const auto mcp_ptr : mc_particles) {
-    auto tlv = Utils::MC::get_tlv(*mcp_ptr);
-  }
-  
+  this->extract_observables(mcps);
+
   // Fill the event data into the tree
   m_tree->Fill();
 }

--- a/source/src/WW/WWProcessor.cc
+++ b/source/src/WW/WWProcessor.cc
@@ -32,10 +32,10 @@ WWProcessor::WWProcessor() : marlin::Processor("WWProcessor") {
       std::string("MCParticle")); // That's the default value, in case
 
   // Register a parameter
-  // registerProcessorParameter("PfoEnergyCut",
-  //   "A cut on pfo energy to apply",
-  //   m_pfoEnergyCut,
-  //   0.f);
+  registerProcessorParameter("OutputFilePath", "Path of the output ROOT file",
+                             m_file_path, std::string("./output.root"));
+  registerProcessorParameter("OutputTreeName", "Name of the output TTree",
+                             m_tree_name, std::string("WWObservables"));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add helper function for reading the LCIO collections.
- Add namespace for helper functions with MC particles, now including function to get particle TLorentzVector.
- Use new helper functions in WW processor.
- Add Utils directory as source directory in CMakeLists.
- Add WW processor subdirectoru to sources in CMakeLists.
- Adapt to MarlinHelp switch to shared library.
- Set path for finding MarlinHelp shared library in environment loading script.
- Add lots of helper functions for MC particles, concerning mainly their identification, interpretation, and finding them in a typical MCParticle vector.
- Add helper struct to collect WW observables.
- Add helper struct to read the header info of an LCIO event into a TTree.
- Add output path and tree name parameters to WW processor.
- Update WW test script to read MiniDST file and specify new output parameters.
- Create a TTree (in a TFile) in the WWProcessor.
- Add HeaderInfo and WWObservables to WWProcessor and add them to the tree.
- Determine the necessary observables in the WWProcessor.