### PR TITLE
Add RK cTGC coefficients

### DIFF
--- a/PrEWInputProduction/CommonHelpers/DistrHelpers.py
+++ b/PrEWInputProduction/CommonHelpers/DistrHelpers.py
@@ -19,11 +19,11 @@ class Coordinate:
 
 # ------------------------------------------------------------------------------
 
-def get_data_1d(root_hist):
+def get_data_1d(root_hist, coords):
     """ Extract data from TH1.
     """
     # Find bin centers and values, skip overflow/underflow bins
-    bin_centers=[]
+    bin_centers_x=[]
     bin_values=[]
     for x_bin in range(0, root_hist.GetNbinsX()+2):
         bin = root_hist.GetBin(x_bin)
@@ -33,21 +33,23 @@ def get_data_1d(root_hist):
             continue
     
         # Collect bin information and fill into array
-        center_x = root_hist.GetXaxis().GetBinCenter(x_bin)
-        center_str = "{}".format(center_x)
-        bin_centers.append(center_str)
+        bin_centers_x.append(root_hist.GetXaxis().GetBinCenter(x_bin))
         
         value = root_hist.GetBinContent(bin)
         bin_values.append(value)
           
-    data = {"Bin centers": bin_centers, "Cross sections": bin_values}
+    data = {
+      "BinCenters:{}".format(coords[0].name) : bin_centers_x, 
+      "Cross sections": bin_values
+    }
     return data
   
-def get_data_2d(root_hist):
+def get_data_2d(root_hist, coords):
     """ Extract data from TH2.
     """
     # Find bin centers and values, skip overflow/underflow bins
-    bin_centers=[]
+    bin_centers_x=[]
+    bin_centers_y=[]
     bin_values=[]
     for x_bin in range(0, root_hist.GetNbinsX()+2):
         for y_bin in range(0, root_hist.GetNbinsY()+2):
@@ -58,22 +60,26 @@ def get_data_2d(root_hist):
                 continue
         
             # Collect bin information and fill into array
-            center_x = root_hist.GetXaxis().GetBinCenter(x_bin)
-            center_y = root_hist.GetYaxis().GetBinCenter(y_bin)
-            center_str = "{}:{}".format(center_x,center_y)
-            bin_centers.append(center_str)
+            bin_centers_x.append(root_hist.GetXaxis().GetBinCenter(x_bin))
+            bin_centers_y.append(root_hist.GetYaxis().GetBinCenter(y_bin))
             
             value = root_hist.GetBinContent(bin)
             bin_values.append(value)
           
-    data = {"Bin centers": bin_centers, "Cross sections": bin_values}
+    data = {
+      "BinCenters:{}".format(coords[0].name) : bin_centers_x, 
+      "BinCenters:{}".format(coords[1].name) : bin_centers_y, 
+      "Cross sections": bin_values
+    }
     return data
   
-def get_data_3d(root_hist):
+def get_data_3d(root_hist, coords):
     """ Extract data from TH3.
     """
     # Find bin centers and values, skip overflow/underflow bins
-    bin_centers=[]
+    bin_centers_x=[]
+    bin_centers_y=[]
+    bin_centers_z=[]
     bin_values=[]
     for x_bin in range(0, root_hist.GetNbinsX()+2):
         for y_bin in range(0, root_hist.GetNbinsY()+2):
@@ -85,21 +91,24 @@ def get_data_3d(root_hist):
                     continue
             
                 # Collect bin information and fill into array
-                center_x = root_hist.GetXaxis().GetBinCenter(x_bin)
-                center_y = root_hist.GetYaxis().GetBinCenter(y_bin)
-                center_z = root_hist.GetZaxis().GetBinCenter(z_bin)
-                center_str = "{}:{}:{}".format(center_x,center_y,center_z)
-                bin_centers.append(center_str)
+                bin_centers_x.append(root_hist.GetXaxis().GetBinCenter(x_bin))
+                bin_centers_y.append(root_hist.GetYaxis().GetBinCenter(y_bin))
+                bin_centers_z.append(root_hist.GetZaxis().GetBinCenter(z_bin))
                 
                 value = root_hist.GetBinContent(bin)
                 bin_values.append(value)
           
-    data = {"Bin centers": bin_centers, "Cross sections": bin_values}
+    data = {
+      "BinCenters:{}".format(coords[0].name) : bin_centers_x, 
+      "BinCenters:{}".format(coords[1].name) : bin_centers_y, 
+      "BinCenters:{}".format(coords[2].name) : bin_centers_z, 
+      "Cross sections": bin_values
+    }
     return data
 
 # ------------------------------------------------------------------------------
 
-def get_data(root_hist):
+def get_data(root_hist, coords):
     """ Extract the bin centers and cross section values from the given
         histogram.
     """
@@ -108,11 +117,11 @@ def get_data(root_hist):
 
     # Exact extraction depends on dimensionality
     if (dim == 1):
-        data = get_data_1d(root_hist)
+        data = get_data_1d(root_hist, coords)
     elif (dim == 2):
-        data = get_data_2d(root_hist)
+        data = get_data_2d(root_hist, coords)
     elif (dim == 3):
-        data = get_data_3d(root_hist)
+        data = get_data_3d(root_hist, coords)
       
     return data
 

--- a/PrEWInputProduction/CommonHelpers/RKCoefMatcher.py
+++ b/PrEWInputProduction/CommonHelpers/RKCoefMatcher.py
@@ -1,0 +1,133 @@
+from copy import copy
+import numpy as np
+from tqdm import tqdm
+
+import RKDistrReader as RKDR
+
+# ------------------------------------------------------------------------------
+
+class RKCoefMatcher:
+    """ Class that helps match the TGC coefficients from Robert Karls 
+        matrix element level distributions to new distributions (from MC).
+    """
+    
+    MC_to_RK_names = {
+        "WW_muminus" : "WW_semilep_MuAntiNu",
+        "WW_muplus" : "WW_semilep_AntiMuNu"
+    }
+    
+    RK_binning = {
+        "WW_semilep_MuAntiNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
+        "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"]
+    }
+    
+    # Sometimes binning is different without affecting coefficients
+    RK_bin_manipulator = {
+        # Roberts WW distribution have a wrong Phi_l^* binning
+        "WW_semilep_MuAntiNu" : [False, False, lambda x: (x - np.pi) * 9.0/10.0],
+        "WW_semilep_AntiMuNu" : [False, False, lambda x: (x - np.pi) * 9.0/10.0]
+    }
+    
+    def __init__(self, RK_distrs=None):
+        self.RK_distrs = [] if (RK_distrs == None) else RK_distrs
+        
+    def add_RK_file(self, file_path, tree_name):
+        """ Use the RK distributions from the tree in the given file.
+        """
+        for distr in RKDR.RKDistrReader(file_path, tree_name).distrs:
+            self.RK_distrs.append(distr)
+
+    def get_distr(self, name):
+        """ Return the distribution of the given name.
+        """
+        found_distrs = []
+        for distr in self.RK_distrs:
+            if (distr.name == name):
+                found_distrs.append(distr)
+                
+        n_found = len(found_distrs)
+        if (n_found == 0):
+            raise ValueError("Didn't find distribution {}".format(name))
+        elif (n_found > 1):
+            raise ValueError("Found more than one distribution {}, found {}".format(name, n_found))
+          
+        return found_distrs[0]    
+
+    def add_coefs_to_data(self, distr_name, eM_chirality, eP_chirality, distr_data):
+        """ Add the correct coefficients to the given distribution.
+            Needs the distribution data which contains the bins.
+        """
+        if not distr_name in self.MC_to_RK_names:
+            print("\tNo coefficients found for {}".format(distr_name))
+            return distr_data
+        
+        RK_name = self.MC_to_RK_names[distr_name]
+        RK_distr = self.get_distr(RK_name)
+        
+        # Dictionary for collecting the coefficients in the right order
+        coef_dict = {}
+        for coef_label in RK_distr.coef_labels:
+            coef_dict[coef_label] = []
+          
+        bin_manipulator = False
+        if RK_name in self.RK_bin_manipulator:
+            bin_manipulator = self.RK_bin_manipulator[RK_name]
+        
+        # Find the coefficients for each bin
+        bin_range = range(len(distr_data["Cross sections"]))
+        for b in tqdm(bin_range, desc="\tMatching coefs for {} e-:{} e+:{}".format(distr_name, eM_chirality, eP_chirality)):
+            # Get the (adjusted coordinates) of
+            coords = [distr_data["BinCenters:{}".format(coord_name)][b] for coord_name in self.RK_binning[RK_name]]
+            
+            # Find the correct bin
+            index = None
+            for b_RK in range(len(RK_distr.bin_centers)):
+                RK_coords = copy(RK_distr.bin_centers[b_RK])
+                # Correct RK coordinates if necessary
+                for c in range(len(RK_coords)):
+                    if bin_manipulator:
+                        if bin_manipulator[c]:
+                            RK_coords[c] = bin_manipulator[c](RK_coords[c])
+                            
+                # Check if coordinates match up
+                if np.all([abs(coords[c] - RK_coords[c]) < 0.001 for c in range(len(coords))]):
+                    index = b_RK
+                    break
+            
+            if index == None:
+                raise ValueError("Didn't find matching bin {} \nAvailable bins : {}".format(coords,RK_distr.bin_centers))
+            
+            # Find and add the appropriate coefs from the RK distribution
+            for co in range(len(RK_distr.coef_labels)):
+                coef = None
+                if (eM_chirality == -1) and (eP_chirality == +1):
+                    coef = RK_distr.coefs_LR[b_RK][co]
+                elif (eM_chirality == +1) and (eP_chirality == -1):
+                    coef = RK_distr.coefs_RL[b_RK][co]
+                elif (eM_chirality == -1) and (eP_chirality == -1):
+                    coef = RK_distr.coefs_LL[b_RK][co]
+                elif (eM_chirality == +1) and (eP_chirality == +1):
+                    coef = RK_distr.coefs_RR[b_RK][co]
+                else:
+                    raise ValueError("Unknown chiralities {} {}".format(eM_chirality, eP_chirality))
+                    
+                coef_dict[RK_distr.coef_labels[co]].append(coef)
+            
+        # Add the coefficients to the distribution data
+        for coef_name, coefs in coef_dict.items():
+            distr_data["Coef:{}".format(coef_name)] = coefs
+            
+        return distr_data
+        
+# ------------------------------------------------------------------------------
+
+def default_coef_matcher():
+    """ Get the default coef matcher that looks in all known RK distributions (at 250 GeV!!!).
+    """
+    matcher = RKCoefMatcher()
+    matcher.add_RK_file("/home/jakob/Documents/DESY/MountPoints/POOLMount/TGCAnalysis/GlobalFit/UnifiedApproach/MinimizationProcessFiles/ROOTfiles/MinimizationProcessesListFile_500_250Full_Elektroweak_menu_2018_04_03.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root", "MinimizationProcesses250GeV")
+    return matcher
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/CommonHelpers/RKDistrReader.py
+++ b/PrEWInputProduction/CommonHelpers/RKDistrReader.py
@@ -73,13 +73,22 @@ class RKDistrReader:
             distr.coefs_LL = np.array([ [float(entry.differential_PNPC_LL[row][col]) for col in range(entry.differential_PNPC_LL.GetNcols())] for row in range(n_rows)])
             distr.coefs_RR = np.array([ [float(entry.differential_PNPC_RR[row][col]) for col in range(entry.differential_PNPC_RR.GetNcols())] for row in range(n_rows)])
             self.distrs.append(distr)
-
-# ------------------------------------------------------------------------------
-
-RKDistrCoords = {
-# "single-W" : [""],
-  "WW" : ["thetaW","thetal","varphil"]
-}
+            
+    def get_distr(self, name):
+        """ Return the distribution of the given name.
+        """
+        found_distrs = []
+        for distr in self.distrs:
+            if (distr.name == name):
+                found_distrs.append(distr)
+                
+        n_found = len(found_distrs)
+        if (n_found == 0):
+            raise ValueError("Didn't find distribution {}".format(name))
+        elif (n_found > 1):
+            raise ValueError("Found more than one distribution {}, found {}".format(name, n_found))
+          
+        return found_distrs[0]
 
 # ------------------------------------------------------------------------------
 

--- a/PrEWInputProduction/CommonHelpers/RKDistrReader.py
+++ b/PrEWInputProduction/CommonHelpers/RKDistrReader.py
@@ -1,0 +1,93 @@
+import ROOT
+import cppyy
+import numpy as np
+
+# ------------------------------------------------------------------------------
+
+""" Classes needed to read the distribution files provided by Robert Karl.
+"""
+
+# ------------------------------------------------------------------------------
+
+class RKDistr:
+    """ Class describing a distribution created by Robert Karl.
+    """
+
+    def __init__(self):
+        self.name = ""
+        self.bin_centers = []
+        
+        self.xsections_LR = []
+        self.xsections_RL = []
+        self.xsections_LL = []
+        self.xsections_RR = []
+        
+        self.coef_labels = []
+        self.coefs_LR = []
+        self.coefs_RL = []
+        self.coefs_LL = []
+        self.coefs_RR = []
+
+# ------------------------------------------------------------------------------
+
+class RKDistrReader:
+    """ Class that can read the distributions (cross sections, bins, 
+        coefficients, ...) that are stores in files created by Robert Karl.
+    """
+    
+    def __init__(self, file_path, tree_name):
+        self.distrs = []
+        
+        # Read the distributions form the file
+        file = ROOT.TFile(file_path)
+        tree = file.Get(tree_name)
+        self.read_distrs(tree)
+        file.Close()
+        
+    def read_distrs(self, tree):
+        """ Read all the distributions from the given file
+        """
+        tree.GetEntry(0)
+        for entry in tree:         
+            # Each entry is a distribution
+            distr = RKDistr()
+            
+            # Extract all the distribution quantities from the tree
+            distr.name = str(entry.describtion)
+            
+            n_rows = entry.angular_center.GetNrows()
+            n_cols = entry.angular_center.GetNcols()
+            if (distr.name in ["Zhadronic", "Zleptonic"]):
+              n_cols = 1 # This is stores falsly in the TTree
+            
+            distr.bin_centers = np.array([[float(entry.angular_center[row][col]) for col in range(n_cols)] for row in range(n_rows)])
+            
+            distr.xsections_LR = [float(xsection) for xsection in entry.differential_sigma_LR]
+            distr.xsections_RL = [float(xsection) for xsection in entry.differential_sigma_RL]
+            distr.xsections_LL = [float(xsection) for xsection in entry.differential_sigma_LL]
+            distr.xsections_RR = [float(xsection) for xsection in entry.differential_sigma_RR]
+            
+            distr.coef_labels = [str(label) for label in entry.differential_PNPC_label]
+            distr.coefs_LR = entry.differential_PNPC_LR
+            distr.coefs_RL = entry.differential_PNPC_RL
+            distr.coefs_LL = entry.differential_PNPC_LL
+            distr.coefs_RR = entry.differential_PNPC_RR
+            self.distrs.append(distr)
+
+# ------------------------------------------------------------------------------
+
+def test():
+    """ Test the RKDistr and RKDistrReader classes.
+    """
+    reader = RKDistrReader(
+        "/home/jakob/Documents/DESY/MountPoints/POOLMount/TGCAnalysis/GlobalFit/UnifiedApproach/MinimizationProcessFiles/ROOTfiles/MinimizationProcessesListFile_500_250Full_Elektroweak_menu_2018_04_03.root",
+        "MinimizationProcesses250GeV"
+    )
+
+# ------------------------------------------------------------------------------
+
+# If this script is called directly (not imported), run the test
+if __name__ == "__main__":
+    test()
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/CommonHelpers/RKDistrReader.py
+++ b/PrEWInputProduction/CommonHelpers/RKDistrReader.py
@@ -62,17 +62,24 @@ class RKDistrReader:
             
             distr.bin_centers = np.array([[float(entry.angular_center[row][col]) for col in range(n_cols)] for row in range(n_rows)])
             
-            distr.xsections_LR = [float(xsection) for xsection in entry.differential_sigma_LR]
-            distr.xsections_RL = [float(xsection) for xsection in entry.differential_sigma_RL]
-            distr.xsections_LL = [float(xsection) for xsection in entry.differential_sigma_LL]
-            distr.xsections_RR = [float(xsection) for xsection in entry.differential_sigma_RR]
+            distr.xsections_LR = np.array([float(xsection) for xsection in entry.differential_sigma_LR])
+            distr.xsections_RL = np.array([float(xsection) for xsection in entry.differential_sigma_RL])
+            distr.xsections_LL = np.array([float(xsection) for xsection in entry.differential_sigma_LL])
+            distr.xsections_RR = np.array([float(xsection) for xsection in entry.differential_sigma_RR])
             
             distr.coef_labels = [str(label) for label in entry.differential_PNPC_label]
-            distr.coefs_LR = entry.differential_PNPC_LR
-            distr.coefs_RL = entry.differential_PNPC_RL
-            distr.coefs_LL = entry.differential_PNPC_LL
-            distr.coefs_RR = entry.differential_PNPC_RR
+            distr.coefs_LR = np.array([ [float(entry.differential_PNPC_LR[row][col]) for col in range(entry.differential_PNPC_LR.GetNcols())] for row in range(n_rows)])
+            distr.coefs_RL = np.array([ [float(entry.differential_PNPC_RL[row][col]) for col in range(entry.differential_PNPC_RL.GetNcols())] for row in range(n_rows)])
+            distr.coefs_LL = np.array([ [float(entry.differential_PNPC_LL[row][col]) for col in range(entry.differential_PNPC_LL.GetNcols())] for row in range(n_rows)])
+            distr.coefs_RR = np.array([ [float(entry.differential_PNPC_RR[row][col]) for col in range(entry.differential_PNPC_RR.GetNcols())] for row in range(n_rows)])
             self.distrs.append(distr)
+
+# ------------------------------------------------------------------------------
+
+RKDistrCoords = {
+# "single-W" : [""],
+  "WW" : ["thetaW","thetal","varphil"]
+}
 
 # ------------------------------------------------------------------------------
 
@@ -80,9 +87,17 @@ def test():
     """ Test the RKDistr and RKDistrReader classes.
     """
     reader = RKDistrReader(
-        "/home/jakob/Documents/DESY/MountPoints/POOLMount/TGCAnalysis/GlobalFit/UnifiedApproach/MinimizationProcessFiles/ROOTfiles/MinimizationProcessesListFile_500_250Full_Elektroweak_menu_2018_04_03.root",
+        # "/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/GlobalFit/UnifiedApproach/MinimizationProcessFiles/ROOTfiles/MinimizationProcessesListFile_500_250Full_Elektroweak_menu_2018_04_03.root",
+        "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root",
         "MinimizationProcesses250GeV"
     )
+    
+    for distr in reader.distrs:
+        print(distr.name)
+        if (len(distr.bin_centers[0]) == 3):
+            print([distr.bin_centers[:,0][10*10*i] for i in range(20)])
+            print([distr.bin_centers[:,1][10*i] for i in range(12)])
+            print(distr.bin_centers[:,2][:12])
 
 # ------------------------------------------------------------------------------
 

--- a/PrEWInputProduction/CommonHelpers/RKDistrReader.py
+++ b/PrEWInputProduction/CommonHelpers/RKDistrReader.py
@@ -67,7 +67,7 @@ class RKDistrReader:
             distr.xsections_LL = np.array([float(xsection) for xsection in entry.differential_sigma_LL])
             distr.xsections_RR = np.array([float(xsection) for xsection in entry.differential_sigma_RR])
             
-            distr.coef_labels = [str(label) for label in entry.differential_PNPC_label]
+            distr.coef_labels = [label for label in str(entry.differential_PNPC_label).split(";") if not label == ""]
             distr.coefs_LR = np.array([ [float(entry.differential_PNPC_LR[row][col]) for col in range(entry.differential_PNPC_LR.GetNcols())] for row in range(n_rows)])
             distr.coefs_RL = np.array([ [float(entry.differential_PNPC_RL[row][col]) for col in range(entry.differential_PNPC_RL.GetNcols())] for row in range(n_rows)])
             distr.coefs_LL = np.array([ [float(entry.differential_PNPC_LL[row][col]) for col in range(entry.differential_PNPC_LL.GetNcols())] for row in range(n_rows)])
@@ -98,6 +98,14 @@ def test():
             print([distr.bin_centers[:,0][10*10*i] for i in range(20)])
             print([distr.bin_centers[:,1][10*i] for i in range(12)])
             print(distr.bin_centers[:,2][:12])
+            
+            for i in range(len(distr.coefs_LR[0])):
+                for b in range(int(len(distr.coefs_LR)/10)):
+                    coefs = distr.coefs_LR[10*b:10*b+10,i]
+                    mean = np.mean(coefs)
+                    std = np.std(coefs)
+                    if ( std > 0.001*abs(mean) ):
+                        print("Bin{}: Coef{}: Mean = {}, Std = {}".format(b,i,mean,std))
 
 # ------------------------------------------------------------------------------
 

--- a/PrEWInputProduction/Readme.md
+++ b/PrEWInputProduction/Readme.md
@@ -8,9 +8,16 @@ Make sure to load modern ROOT (e.g. 6.18) and Python (e.g. 3.8) versions. Some a
 
 ## Usage
 
+Proper (modern) Python and ROOT versions must be loaded to run the scripts.
+On the NAF system this can be done using the `load_python_env.sh` script.
+
+```shell
+  source load_python_env.sh
+```
+
 Each process has its own folder. The script that is named `[process].py` can be executed with Python to produce the PrEW input sample, e.g.:
 
-```
+```shell
   cd WW && python WW.py
 ```
 

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -11,6 +11,7 @@ import CSVMetadata as CSVM
 import DistrHelpers as DH
 import InputHelpers as IH
 import OutputHelpers as OH
+import RKCoefMatcher as RKCM
 
 # ------------------------------------------------------------------------------
 
@@ -63,8 +64,14 @@ def create_WW_output(input, output, coords, cuts):
 
     # ----------------------- Producing PrEW input -----------------------------
 
+    # Extract bin centers and cross sections from the histogram
+    data = DH.get_data(th3, coords)
+    
+    # Try to find coefficients from RK distribution
+    coef_matcher = RKCM.default_coef_matcher()
+    data = coef_matcher.add_coefs_to_data(output.distr_name, eM_chi, eP_chi, data)
+    
     # Create a pandas dataframe
-    data = DH.get_data(th3)
     df = pd.DataFrame(data)
 
     # Write the dataframe to a csv file
@@ -102,8 +109,6 @@ def main():
         DH.Coordinate("costh_l_star", 10, -0.925925925925926, 0.925925925925926),
         DH.Coordinate("phi_l_star", 10, -math.pi, math.pi),
     ]
-
-    #  TODO Change metadata setup for coordinates (making it same for coefficients: COORD:coord_name, COEF:coef_name) => In ROOT find those branches
 
     # Create all WW distributions
     create_WW_output(

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -88,11 +88,13 @@ def main():
 
     # Input
     input = IH.InputInfo(
-        file_path = "/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/NewMCProduction/Test/WWtest.root",
+        # file_path = "/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/NewMCProduction/Test/WWtest.root",
+        file_path = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/Test/WWtest.root",
         tree_name = "WWObservables", energy = 250)
 
     # Output settings
-    output_dir = "/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/NewMCProduction/WW"
+    # output_dir = "/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/NewMCProduction/WW"
+    output_dir = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/WW"
 
     # Coordinates
     coords = [
@@ -100,6 +102,8 @@ def main():
         DH.Coordinate("costh_l_star", 20, -1, 1),
         DH.Coordinate("phi_l_star", 20, -math.pi, math.pi),
     ]
+
+    #  TODO Change metadata setup for coordinates (making it same for coefficients: COORD:coord_name, COEF:coef_name) => In ROOT find those branches
 
     # Create all WW distributions
     create_WW_output(

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -98,9 +98,9 @@ def main():
 
     # Coordinates
     coords = [
-        DH.Coordinate("costh_Wminus_star", 20, -1, 1),
-        DH.Coordinate("costh_l_star", 20, -1, 1),
-        DH.Coordinate("phi_l_star", 20, -math.pi, math.pi),
+        DH.Coordinate("costh_Wminus_star", 20, -0.9695290858725761, 0.9695290858725761),
+        DH.Coordinate("costh_l_star", 10, -0.925925925925926, 0.925925925925926),
+        DH.Coordinate("phi_l_star", 10, -math.pi, math.pi),
     ]
 
     #  TODO Change metadata setup for coordinates (making it same for coefficients: COORD:coord_name, COEF:coef_name) => In ROOT find those branches

--- a/PrEWInputProduction/load_python_env.sh
+++ b/PrEWInputProduction/load_python_env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "#########################################################################"
+echo "### Loading needed software versions ####################################" 
+echo "#########################################################################"
+
+# Load a modern LCG version (a full view including ROOT and Python3)
+lcg_version=98python3
+
+if [[ "${LCG_VERSION}" == "${lcg_version}" ]]; then 
+  echo "LCG view already loaded."
+elif [ ! -z "${LCG_VERSION}" ]; then
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "ERROR: Another LCG view is already loaded!"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+else 
+  echo "Loading LCG view - version: ${lcg_version}" 
+  source /cvmfs/sft.cern.ch/lcg/views/LCG_${lcg_version}/x86_64-centos7-gcc8-opt/setup.sh
+fi  

--- a/macros/load_env.sh
+++ b/macros/load_env.sh
@@ -5,7 +5,8 @@ echo "### Loading needed software versions ####################################"
 echo "#########################################################################"
 
 # Load up-to-date iLCSoft 
-ilcsoft_dir="/cvmfs/ilc.desy.de/sw/x86_64_gcc82_sl6/v02-02"
+ilcsoft_version="v02-02"
+ilcsoft_dir="/cvmfs/ilc.desy.de/sw/x86_64_gcc82_sl6/${ilcsoft_version}"
 
 if [[ "${ILCSOFT}" == *"${ilcsoft_dir}"* ]]; then
   echo "iLCSoft version is already loaded."
@@ -14,6 +15,7 @@ elif [ ! -z "${ILCSOFT}" ]; then
   echo "ERROR: Another iLCSoft version is already loaded!"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 else 
+  echo "Loading iLCSoft - version: ${ilcsoft_version}"
   source ${ilcsoft_dir}/init_ilcsoft.sh
 fi
 


### PR DESCRIPTION
- Add a Python class to the Python common helpers that reads RK distributions.
- Add script to load proper python environment on NAF.
- Make environment loading more verbose.
- Document loading of python environment on NAF.
- Investigate distribution binning in test of RKDistrReader.
- Fix coef label reading in RKDistrReader.
- Print the bin centers in the RKDistrReader test code.
- Add a get functionality to the RKDistrReader.
- Change the saving of bin centers in DistrHelpers so that each dimension is a column with name BinCenter:DimensionName.
- Add a coefficient matcher between MC and RK style distributions in the python script.
- Fix WW coordinates by taking into account generator level cut used in Roberts distributions.
- Use coefficient matching in WW PrEW input creation.