### PR TITLE
Enable muon acceptance coefficient calculation

### DIFF
--- a/PrEWInputProduction/CommonHelpers/CSVMetadata.py
+++ b/PrEWInputProduction/CommonHelpers/CSVMetadata.py
@@ -10,6 +10,8 @@ class CSVMetadata:
         "e- chirality": "e-Chirality",
         "e+ chirality": "e+Chirality"
     }
+    
+    coef_marker = "Coef"
 
     def __init__(self):
         self.metadata = {}
@@ -19,16 +21,24 @@ class CSVMetadata:
         """
         if not name in self.marker_map.keys():
             raise ValueError(
-                "Unknown attribute {}, only know {}.", name, self.marker_map.keys())
+                "Unknown attribute {}, only know {}.", self.marker_map[name], self.marker_map.keys())
         else:
             self.metadata[name] = value
+            
+    def add_coef(self, base_name, coef_name, value):
+        """ Add a global coefficient as metadata.
+            Requires the base_name (describing the thing the coef is about),
+            the specific coef_name and its value.
+        """
+        full_name = "{}|{}_{}".format(self.coef_marker,base_name,coef_name)
+        self.metadata[full_name] = value
 
     def get_metadata_str(self):
         """ Get the current metadata string.
         """
         metadata_str = self.begin_marker + "\n"
         for name, value in self.metadata.items():
-            metadata_str += "{}: {}\n".format(self.marker_map[name], value)
+            metadata_str += "{}: {}\n".format(name, value)
         metadata_str += self.end_marker + "\n"
         return metadata_str
 

--- a/PrEWInputProduction/CommonHelpers/DistrHelpers.py
+++ b/PrEWInputProduction/CommonHelpers/DistrHelpers.py
@@ -209,3 +209,65 @@ def get_hist_ptr(rdf, distr_name, coords):
     return hist_ptr
 
 # ------------------------------------------------------------------------------
+
+def get_bin_range_1d(hist):
+    """ Return correct index range for 1D histogram. """
+    bin_range = []
+    for x_bin in range(0, hist.GetNbinsX()+2):
+          bin = hist.GetBin(x_bin)
+              
+          # Skip overflow and underflow bins
+          if hist.IsBinUnderflow(bin) or hist.IsBinOverflow(bin): 
+              continue
+          
+          bin_range.append(bin)
+    return bin_range
+          
+    
+def get_bin_range_2d(hist):
+    """ Return correct index range for 2D histogram. """
+    bin_range = []
+    for x_bin in range(0, hist.GetNbinsX()+2):
+        for y_bin in range(0, hist.GetNbinsY()+2):
+            bin = hist.GetBin(x_bin, y_bin)
+            
+            # Skip overflow and underflow bins
+            if hist.IsBinUnderflow(bin) or hist.IsBinOverflow(bin): 
+                continue
+
+            bin_range.append(bin)
+    return bin_range
+
+
+def get_bin_range_3d(hist):
+    """ Return correct index range for 3D histogram. """
+    bin_range = []
+    for x_bin in range(0, hist.GetNbinsX()+2):
+        for y_bin in range(0, hist.GetNbinsY()+2):
+            for z_bin in range(0, hist.GetNbinsZ()+2):
+                bin = hist.GetBin(x_bin, y_bin, z_bin)
+                
+                # Skip overflow and underflow bins
+                if hist.IsBinUnderflow(bin) or hist.IsBinOverflow(bin): 
+                    continue
+
+                bin_range.append(bin)
+    return bin_range
+
+def get_bin_range(hist):
+    """ Return the bin index range that corresponds to the way the bin 
+        coordinates where extracted from the histogram.
+    """
+    bin_range = []
+    dim = hist.GetDimension()
+    if (dim == 1):
+        bin_range = get_bin_range_1d(hist)
+    elif (dim == 2):
+        bin_range = get_bin_range_2d(hist)
+    elif (dim == 3):
+        bin_range = get_bin_range_3d(hist)
+    else:
+        raise ValueError("Invalid hist dimension: {}".format(dim))
+    return bin_range
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/CommonHelpers/RKCoefMatcher.py
+++ b/PrEWInputProduction/CommonHelpers/RKCoefMatcher.py
@@ -75,7 +75,7 @@ class RKCoefMatcher:
         
         # Find the coefficients for each bin
         bin_range = range(len(distr_data["Cross sections"]))
-        for b in tqdm(bin_range, desc="\tMatching coefs for {} e-:{} e+:{}".format(distr_name, eM_chirality, eP_chirality)):
+        for b in tqdm(bin_range, desc="\tMatching RK coefs"):
             # Get the (adjusted coordinates) of
             coords = [distr_data["BinCenters:{}".format(coord_name)][b] for coord_name in self.RK_binning[RK_name]]
             

--- a/PrEWInputProduction/Cuts/MuonAcceptance.py
+++ b/PrEWInputProduction/Cuts/MuonAcceptance.py
@@ -1,0 +1,155 @@
+import DistrHelpers as DH
+
+import ROOT
+from tqdm import tqdm
+
+# ------------------------------------------------------------------------------
+
+def get_costh_cut(cut_val, center_shift, width_shift, costh_branch):
+  """ Get the string that describes the cos(theta) cut for the given cut values.
+      Four inputs are needed:
+        The central cut value (same for both sides +-).
+        The change that of the acceptance center (center_shift).
+        The change that of the acceptance width (width_shift).
+        The name of the cos(Theta) branch.
+  """
+  pos_cut =   abs(cut_val) + center_shift + width_shift
+  neg_cut = - abs(cut_val) + center_shift - width_shift  
+  cut_str = "({} > {}) && ({} < {})".format(costh_branch, neg_cut, costh_branch,
+                                            pos_cut)
+  return cut_str
+  
+
+# ------------------------------------------------------------------------------
+
+def get_coef_data(hist_nocut, hist_0, hist_c, hist_2c, hist_w, hist_2w, hist_cw, 
+                  delta):
+  """ Calculate all the coefficients and return them in a dictionary that can be
+      written out by pandas into CSV.
+      Six histograms are needed:
+        - original without any cut at all
+        w/ cut:
+          - initial cut
+          - center moved by delta
+          - center moved by 2*delta
+          - width moved by delta
+          - width moved by 2*delta
+          - center moved by delta and width moved by delta
+      In addition, the value for delta is needed
+  """
+  # Coefficients to collect:
+  k_0 = []
+  k_c = []
+  k_w = []
+  k_c2 = []
+  k_w2 = []
+  k_cw = []
+  
+  # Doing this in loop instead of with TH1-operators to control each case
+  bin_range = DH.get_bin_range(hist_nocut)
+  for bin in tqdm(bin_range, desc="\tCalculate muon acc. coefs"):
+    # Skip overflow and underflow bins
+    if hist_nocut.IsBinUnderflow(bin) or hist_nocut.IsBinOverflow(bin): 
+      continue
+      
+    N_nocut = hist_nocut.GetBinContent(bin)
+    if (N_nocut < 3.5):
+      # Got too few MC events to say anything about the behaviour
+      k_0.append(1.0) # Constant term 1, all other 0
+      for k in [k_c, k_w, k_c2, k_w2, k_cw]:
+        k.append(0.0)
+      continue 
+    
+    R_0 = float(hist_0.GetBinContent(bin)) / N_nocut
+    R_c = float(hist_c.GetBinContent(bin)) / N_nocut
+    R_2c = float(hist_2c.GetBinContent(bin)) / N_nocut
+    R_w = float(hist_w.GetBinContent(bin)) / N_nocut
+    R_2w = float(hist_2w.GetBinContent(bin)) / N_nocut
+    R_cw = float(hist_cw.GetBinContent(bin)) / N_nocut
+    
+    # Actual calculation of the coefficients
+    k_0.append(R_0)
+    k_c.append( 1.0/delta * (-1.5*R_0 + 2.0*R_c - 0.5*R_2c) )
+    k_w.append( 1.0/delta * (-1.5*R_0 + 2.0*R_w - 0.5*R_2w) )
+    k_c2.append( 1.0/delta**2 * (0.5*R_0 - R_c + 0.5*R_2c) )
+    k_w2.append( 1.0/delta**2 * (0.5*R_0 - R_w + 0.5*R_2w) )
+    k_cw.append( 1.0/delta**2 * (R_0 + R_cw - R_c - R_w) )
+
+  return {"MuonAcc_k0": k_0, 
+          "MuonAcc_kc": k_c, "MuonAcc_kw": k_w, 
+          "MuonAcc_kc2": k_c2, "MuonAcc_kw2": k_w2, "MuonAcc_kcw": k_cw}
+
+# ------------------------------------------------------------------------------
+
+class MuonAccParametrisation:
+  """ Class that can calculate the coefficients required in the parametrisation 
+      of the muon acceptance. 
+      Muon acceptance is here defined as a simple box acceptance with the same
+      cut value on both sides.
+      For the parametrisation both sides are varied either 
+        - by keeping the acceptance width constant and shifting the center 
+          (center_shift) or 
+        - by keeping the center constant and changing the width (width_shift).
+  """
+  
+  def __init__(self, rdf, cut_val, delta, costh_branch, distr_name, coords):
+    """ Takes four cut-related inputs:
+          The dataframe that can be used to extract the changes with the cuts.
+          The initial cut value which is the same on both side (+-cos(theta)).
+          The deviation that is used in the test to find the cut-dependence.
+          The name of the cos(Theta_muon) branch.
+        And two histogram-related input (name and coordinate information).
+    """
+    self.cut_val = cut_val
+    self.delta = delta
+    
+    # Five different cuts are tested 
+    rdf_0 =  rdf.Filter(get_costh_cut(cut_val, 0, 0, costh_branch))
+    rdf_c =  rdf.Filter(get_costh_cut(cut_val, delta, 0, costh_branch))
+    rdf_2c = rdf.Filter(get_costh_cut(cut_val, 2*delta, 0, costh_branch))
+    rdf_w =  rdf.Filter(get_costh_cut(cut_val, 0, delta, costh_branch))
+    rdf_2w = rdf.Filter(get_costh_cut(cut_val, 0, 2*delta, costh_branch))
+    rdf_cw = rdf.Filter(get_costh_cut(cut_val, delta, delta, costh_branch))
+  
+    self.histptr_nocut =  DH.get_hist_ptr(rdf, distr_name + "_nocut", coords)
+    self.histptr_0 =  DH.get_hist_ptr(rdf_0, distr_name + "_0", coords)
+    self.histptr_c =  DH.get_hist_ptr(rdf_c, distr_name + "_c", coords)
+    self.histptr_2c = DH.get_hist_ptr(rdf_2c, distr_name + "_2c", coords)
+    self.histptr_w =  DH.get_hist_ptr(rdf_w, distr_name + "_w", coords)
+    self.histptr_2w = DH.get_hist_ptr(rdf_2w, distr_name + "_2w", coords)
+    self.histptr_cw = DH.get_hist_ptr(rdf_cw, distr_name + "_cw", coords)
+  
+  def add_coefs_to_data(self, distr_data):
+    """ Parametrisation uses 2nd order polynomial approach for 2 parameters.
+        Details are not described here (probably in PrEW, else in thesis).
+        Coefficients are added to data.
+    """
+    hist_nocut = self.histptr_0.GetValue()
+    hist_0 =  self.histptr_0.GetValue()
+    hist_c =  self.histptr_c.GetValue()
+    hist_2c = self.histptr_2c.GetValue()
+    hist_w =  self.histptr_w.GetValue()
+    hist_2w = self.histptr_2w.GetValue()
+    hist_cw = self.histptr_cw.GetValue()
+    
+    coef_data = get_coef_data(hist_nocut, hist_0, hist_c, hist_2c, hist_w, 
+                              hist_2w, hist_cw, self.delta)
+    
+    for coef_name, coefs in coef_data.items():
+        distr_data["Coef:{}".format(coef_name)] = coefs
+    
+    return distr_data
+    
+  def add_coefs_to_metadata(self, metadata):
+    """ Add the needed global coefficients to the metadata.
+    """
+    metadata.add_coef("MuonAcc","CutValue",self.cut_val)
+    
+# ------------------------------------------------------------------------------
+
+def default_acc_cut():
+  """ Define the default acceptance cut for the muon acceptance box.
+  """
+  return 0.95
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -12,6 +12,8 @@ import DistrHelpers as DH
 import InputHelpers as IH
 import OutputHelpers as OH
 import RKCoefMatcher as RKCM
+sys.path.append("../Cuts")
+import MuonAcceptance as CMA
 
 # ------------------------------------------------------------------------------
 
@@ -39,6 +41,11 @@ def create_WW_output(input, output, coords, cuts):
     eP_chi = eP_chi_ptr.GetValue()
     n_after_cuts = n_after_cuts_ptr.GetValue()
     th3 = th3_ptr.GetValue()
+
+    # Prepare the muon acceptance box
+    muon_acc_cut = CMA.default_acc_cut()
+    muon_acc = CMA.MuonAccParametrisation(rdf_after_cuts, muon_acc_cut, 0.001, 
+                                          "costh_l", output.distr_name, coords)
 
     print("For distr {}:\n\tBefore cuts: {} , after cuts: {} ({}%)".format(
         output.distr_name, n_total, n_after_cuts, n_after_cuts/n_total*100.0))
@@ -71,6 +78,9 @@ def create_WW_output(input, output, coords, cuts):
     coef_matcher = RKCM.default_coef_matcher()
     data = coef_matcher.add_coefs_to_data(output.distr_name, eM_chi, eP_chi, data)
     
+    # Try extracting the differential coefficients for the muon acceptance box
+    data = muon_acc.add_coefs_to_data(data)
+    
     # Create a pandas dataframe
     df = pd.DataFrame(data)
 
@@ -84,6 +94,7 @@ def create_WW_output(input, output, coords, cuts):
     metadata.add("energy", input.energy)
     metadata.add("e- chirality", eM_chi)
     metadata.add("e+ chirality", eP_chi)
+    muon_acc.add_coefs_to_metadata(metadata)
     metadata.write(file_path)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Decrease the tqdm output in RKCoefMatcher.
- Enable adding of coefficients to the CSV metadata.
- Add functions to DistrHelpers that returns a consistent way of how one should loop over bins.
- Add class that calculates and sets up all the coefficients needed to describe the bin-by-bin dependence on a muon acceptance cut.
- Use the muon acceptance cut calculation in the WW python script.