### PR TITLE
Change and improve WW angles

### DIFF
--- a/PrEWInputProduction/RKHelp/RKCoefMatcher.py
+++ b/PrEWInputProduction/RKHelp/RKCoefMatcher.py
@@ -25,8 +25,8 @@ class RKCoefMatcher:
     # Sometimes binning is different (without affecting the cross section)
     RK_bin_manipulator = {
       # Roberts WW distribution have a wrong Phi_l^* binning
-      "WW_semilep_MuAntiNu" : lambda x: np.array([x[0], -x[1], (x[2] - np.pi) * 9.0/10.0]),
-      "WW_semilep_AntiMuNu" : lambda x: np.array([x[0], -x[1], (x[2] - np.pi) * 9.0/10.0])
+      "WW_semilep_MuAntiNu" : lambda x: np.array([x[0], x[1], (x[2] - np.pi) * 9.0/10.0]),
+      "WW_semilep_AntiMuNu" : lambda x: np.array([x[0], x[1], (x[2] - np.pi) * 9.0/10.0])
     }
     
     def __init__(self, RK_distrs=None):

--- a/macros/FullProduction/configure_script.sh
+++ b/macros/FullProduction/configure_script.sh
@@ -6,6 +6,7 @@
 script_path=false
 input_file=false
 output_file=false
+unboost_crossing_angle=""
 
 # ------------------------------------------------------------------------------
 # Read input
@@ -24,8 +25,12 @@ case $i in
     output_file="${i#*=}"
     shift # past argument=value
   ;;
+  --unboost-crossing-angle=*)
+    unboost_crossing_angle="${i#*=}"
+    shift # past argument=value
+  ;;
   -h|--help)
-    echo "usage: ./configure_script.sh --script-path=[...] [--input-file=...] [--output-file=...]"
+    echo "usage: ./configure_script.sh --script-path=[...] [--input-file=...] [--output-file=...] [--unboost-crossing-angle=[true,false]]"
     shift # past argument=value
   ;;
   *)
@@ -63,6 +68,15 @@ if [ "$output_file" != false ]; then
   token=OUTPUT_FILE_TOKEN
   replacement=$output_file
   replace_token
+fi
+
+# Crossing angle token must be set either way
+if [ "$unboost_crossing_angle" != "" ]; then
+  token=UNBOOST_CROSSINGANGLE_TOKEN
+  replacement=$unboost_crossing_angle
+  replace_token
+else 
+  >&2 echo "Need to knew if crossing angle should be unboosted! Must be given in input config using unboost_crossing_angle variable."; exit 1
 fi
 
 # ------------------------------------------------------------------------------

--- a/macros/FullProduction/manage_process_files.sh
+++ b/macros/FullProduction/manage_process_files.sh
@@ -141,7 +141,7 @@ if  [[ ${action} == "set" ]]; then
     fi
     
     cp ${template_path} ${tmp_steering_file}
-    ${dir}/configure_script.sh --script-path=${tmp_steering_file} --input-file=${file} --output-file=${tmp_output_file}
+    ${dir}/configure_script.sh --script-path=${tmp_steering_file} --input-file=${file} --output-file=${tmp_output_file} --unboost-crossing-angle=${unboost_crossing_angle}
     
     file_steering_paths+="${tmp_steering_file} " # Keep track of steering file for job starting
   done

--- a/macros/FullProduction/run_single_process.sh
+++ b/macros/FullProduction/run_single_process.sh
@@ -116,7 +116,14 @@ for e_pol in "${e_polarizations[@]}"; do
     echo "Waiting for jobs of ${process} ${e_pol} ${p_pol} to finish."
     for job_ID in ${condor_job_IDs[@]}; do
       job_log_path=$(ls ${condor_output_dir}/${job_ID}*.log)
-      wait_output=$(condor_wait ${job_log_path}) # Write into variable to suppress spammy output
+      
+      # Write into variable to suppress spammy output.
+      # Timeout after 15 seconds to restart command, else it gets stuck sometimes.
+      status=124 # Start with error code to get into loop
+      while [ $status -eq 124 ]; do
+        wait_output=$(timeout 15 condor_wait ${job_log_path}) 
+        status=$? # Update status -> 124 means timeout, else success
+      done
     done
     echo "Jobs of ${process} ${e_pol} ${p_pol} finished!"
     

--- a/scripts/config/input_250.config
+++ b/scripts/config/input_250.config
@@ -1,1 +1,5 @@
 input_dir=/pnfs/desy.de/ilc/prod/ilc/mc-2020/generated/250-SetA
+
+# These are generator level files, the particles were not boosted into a 
+# crossing angle yet
+unboost_crossing_angle=false

--- a/scripts/templates/4f_WW_sl.xml
+++ b/scripts/templates/4f_WW_sl.xml
@@ -25,6 +25,9 @@
   <processor name="MyWWProcessor" type="WWProcessor">
     <!-- The MC particle collection name -->
     <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="UnboostCrossingAngle"> 
+      UNBOOST_CROSSINGANGLE_TOKEN
+    </parameter>
     <parameter name="OutputFilePath"> 
       OUTPUT_FILE_TOKEN
     </parameter>

--- a/source/include/Utils/MC.h
+++ b/source/include/Utils/MC.h
@@ -10,6 +10,7 @@
 #include <EVENT/MCParticle.h>
 
 // Standard library
+#include <string>
 #include <vector>
 
 namespace Utils {
@@ -53,6 +54,10 @@ EVENT::MCParticle *incoming_eP_after_ISR(const EVENT::MCParticleVec &vec);
 // --- Create MCParticles ------------------------------------------------------
 IMPL::MCParticleImpl create_W(const EVENT::MCParticle &mcp1,
                            const EVENT::MCParticle &mcp2);
+// -----------------------------------------------------------------------------
+
+// --- Print out related -------------------------------------------------------
+std::string print(const EVENT::MCParticle &mcp);
 // -----------------------------------------------------------------------------
 
 } // namespace MC

--- a/source/include/WW/WWProcessor.h
+++ b/source/include/WW/WWProcessor.h
@@ -74,6 +74,9 @@ private:
 
   // --- Input parameters ------------------------------------------------------
   std::string m_mcCollectionName = {""};
+
+  bool m_unboost_xangle {true};
+
   std::string m_file_path{""};
   std::string m_tree_name{""};
 
@@ -82,9 +85,9 @@ private:
   // TFile and TTree with result output
   std::unique_ptr<TFile> m_file{};
   TTree *m_tree{}; // Needs to be pure pointer, belongs to file
-  
+
   // Output information
-  Utils::HeaderInfo m_header {};
+  Utils::HeaderInfo m_header{};
   WW::WWObservables m_observables{};
 
   // Internal functions

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -368,4 +368,16 @@ IMPL::MCParticleImpl MC::create_W(const EVENT::MCParticle &mcp1,
 
 //------------------------------------------------------------------------------
 
+std::string MC::print(const EVENT::MCParticle &mcp) {
+  /** Return a string of some vital information of the MC particle.
+   **/
+  return std::string("E: ") + std::to_string(mcp.getEnergy()) + 
+        " Px: " + std::to_string(mcp.getMomentum()[0]) +
+        " Py: " + std::to_string(mcp.getMomentum()[1]) +
+        " Pz: " + std::to_string(mcp.getMomentum()[2]);
+        " Charge: " + std::to_string(mcp.getCharge());
+}
+
+//------------------------------------------------------------------------------
+
 } // namespace Utils

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -374,7 +374,7 @@ std::string MC::print(const EVENT::MCParticle &mcp) {
   return std::string("E: ") + std::to_string(mcp.getEnergy()) + 
         " Px: " + std::to_string(mcp.getMomentum()[0]) +
         " Py: " + std::to_string(mcp.getMomentum()[1]) +
-        " Pz: " + std::to_string(mcp.getMomentum()[2]);
+        " Pz: " + std::to_string(mcp.getMomentum()[2]) +
         " Charge: " + std::to_string(mcp.getCharge());
 }
 

--- a/source/src/WW/Processor/extract_Wl_observables.cpp
+++ b/source/src/WW/Processor/extract_Wl_observables.cpp
@@ -10,8 +10,8 @@ void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
   /** Extract the lepton observables in the leptonically decaying W system.
       Need angles in W rest frame and with z' axis along W_l flight direction:
       1. Boost into e+e- system after ISR
-      2. Boost into W_l system
-      3. Rotate to be along W_l axis
+      2. Rotate to be along W_l axis
+      3. Boost into W_l system
       4. Extract angles
    **/
   // Lorentz vectors in lab frame

--- a/source/src/WW/Processor/extract_Wl_observables.cpp
+++ b/source/src/WW/Processor/extract_Wl_observables.cpp
@@ -21,8 +21,6 @@ void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
   // Lorentz vectors in e+e- frame (after removing crossing angle)
   auto energy = m_header.m_energy;
   auto eM_tlv_ee = TLorentzVector(0, 0, energy, energy); // e- in z direction
-  auto l_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
-      l_tlv_lab, m_header.m_energy);
   
   auto Wl_tlv_ee = Wl_tlv_lab;
   if (m_unboost_xangle) {
@@ -30,8 +28,9 @@ void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
         MarlinHelp::ILD::Machine::unboost_crossing_angle(Wl_tlv_lab, energy);
   }
 
-  // Boost into the W system (boosting e- not necessary, just less confusing)
-  auto l_tlv_Wl = MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_lab, Wl_tlv_ee);
+  // Lorentz vectors in W_l system
+  auto l_tlv_Wl =
+      MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_lab, Wl_tlv_lab);
 
   // Rotate to be along W flight direction (x in e-W plane)
   // (Previous boost was along W direction, so e-W plane didn't change)

--- a/source/src/WW/Processor/extract_Wl_observables.cpp
+++ b/source/src/WW/Processor/extract_Wl_observables.cpp
@@ -23,8 +23,12 @@ void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
   auto eM_tlv_ee = TLorentzVector(0, 0, energy, energy); // e- in z direction
   auto l_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
       l_tlv_lab, m_header.m_energy);
-  auto Wl_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
-      Wl_tlv_lab, m_header.m_energy);
+  
+  auto Wl_tlv_ee = Wl_tlv_lab;
+  if (m_unboost_xangle) {
+    Wl_tlv_ee =
+        MarlinHelp::ILD::Machine::unboost_crossing_angle(Wl_tlv_lab, energy);
+  }
 
   // Boost into the W system (boosting e- not necessary, just less confusing)
   auto l_tlv_Wl = MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_lab, Wl_tlv_ee);

--- a/source/src/WW/Processor/extract_Wl_observables.cpp
+++ b/source/src/WW/Processor/extract_Wl_observables.cpp
@@ -21,21 +21,25 @@ void WWProcessor::extract_Wl_observables(const EVENT::MCParticle &Wl,
   // Lorentz vectors in e+e- frame (after removing crossing angle)
   auto energy = m_header.m_energy;
   auto eM_tlv_ee = TLorentzVector(0, 0, energy, energy); // e- in z direction
-  
+
+  auto l_tlv_ee = l_tlv_lab;
   auto Wl_tlv_ee = Wl_tlv_lab;
   if (m_unboost_xangle) {
+    l_tlv_ee =
+        MarlinHelp::ILD::Machine::unboost_crossing_angle(l_tlv_lab, energy);
     Wl_tlv_ee =
         MarlinHelp::ILD::Machine::unboost_crossing_angle(Wl_tlv_lab, energy);
   }
 
-  // Lorentz vectors in W_l system
-  auto l_tlv_Wl =
-      MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_lab, Wl_tlv_lab);
+  // Rotate to be along W flight direction (x in e-W plane, z along W flight)
+  auto l_tlv_ee_rot =
+      MarlinHelp::Root::LorentzVec::rotate_into(l_tlv_ee, Wl_tlv_ee, eM_tlv_ee);
+  auto Wl_tlv_ee_rot = MarlinHelp::Root::LorentzVec::rotate_into(
+      Wl_tlv_ee, Wl_tlv_ee, eM_tlv_ee);
 
-  // Rotate to be along W flight direction (x in e-W plane)
-  // (Previous boost was along W direction, so e-W plane didn't change)
+  // Lorentz vectors in W_l system
   auto l_tlv_Wl_rot =
-      MarlinHelp::Root::LorentzVec::rotate_into(l_tlv_Wl, Wl_tlv_ee, eM_tlv_ee);
+      MarlinHelp::Root::LorentzVec::boost_tlv(l_tlv_ee_rot, Wl_tlv_ee_rot);
 
   // --- Find observables ------------------------------------------------------
   m_observables.costh_l_star = l_tlv_Wl_rot.CosTheta();

--- a/source/src/WW/Processor/extract_ee_observables.cpp
+++ b/source/src/WW/Processor/extract_ee_observables.cpp
@@ -11,8 +11,11 @@ void WWProcessor::extract_ee_observables(const EVENT::MCParticle &Wminus) {
   auto Wminus_tlv_lab = Utils::MC::get_tlv(Wminus);
 
   // Lorentz vectors in e+e- frame (after removing crossing angle)
-  auto Wminus_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
-      Wminus_tlv_lab, m_header.m_energy);
+  auto Wminus_tlv_ee = Wminus_tlv_lab;
+  if (m_unboost_xangle) {
+    Wminus_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+        Wminus_tlv_lab, m_header.m_energy);
+  }
 
   // --- Find observables ------------------------------------------------------
   m_observables.costh_Wminus_star = Wminus_tlv_ee.CosTheta();

--- a/source/src/WW/Processor/extract_observables.cpp
+++ b/source/src/WW/Processor/extract_observables.cpp
@@ -1,13 +1,17 @@
 #include <Utils/MC.h>
 #include <WW/WWProcessor.h>
 
+// Includes from iLCSoft
+#include "streamlog/streamlog.h"
+
 void WWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
   /** Extract the relevant generator level observables.
    **/
   // Find the first lepton (skip the initial e+e- and ISR -> skip 8)
   auto l = Utils::MC::find_first_lepton(mcps, 8);
-  m_observables.l_charge = int(l->getCharge());
+  streamlog_out(DEBUG) << "Found l: " << Utils::MC::print(*l) << std::endl; 
 
+  m_observables.l_charge = int(l->getCharge());
   if (Utils::MC::is_mu(*l))
     m_observables.decay_to_mu = true;
   if (Utils::MC::is_tau(*l))
@@ -28,6 +32,9 @@ void WWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
     W_h_tech = Utils::MC::determine_W(mcps, -1 * m_observables.l_charge);
     W_h = &W_h_tech;
   }
+
+  streamlog_out(DEBUG) << "Found W_l: " << Utils::MC::print(*W_l) << std::endl; 
+  streamlog_out(DEBUG) << "Found W_h: " << Utils::MC::print(*W_h) << std::endl; 
 
   // Which one is W+, which one W-?
   auto Wplus = W_l;

--- a/source/src/WW/WWProcessor.cc
+++ b/source/src/WW/WWProcessor.cc
@@ -30,7 +30,11 @@ WWProcessor::WWProcessor() : marlin::Processor("WWProcessor") {
                           // file parsing
       std::string("MCParticle")); // That's the default value, in case
 
-  // Register a parameter
+  // Register input parameters
+  registerProcessorParameter("UnboostCrossingAngle",
+                             "Should the crossing angle be unboosted?",
+                             m_unboost_xangle, bool(true));
+
   registerProcessorParameter("OutputFilePath", "Path of the output ROOT file",
                              m_file_path, std::string("./output.root"));
   registerProcessorParameter("OutputTreeName", "Name of the output TTree",


### PR DESCRIPTION
- Undo artificial coordinate sign correction in WW python macro.
- Make unboosting the crossing angle in the WW processor optional, can be steered with process parameter.
- Fix the calculation of the W_lep system observables in WW processor.
- Add crossing angle boost token to WW template and crossing angle command to WW 250 input config.
- Make production macros read from the input config whether the crossing angle for those files should be boosted away.
- Saveguard condor_wait against getting stuck by using a timeout while loop.
- Switch order of boost and rotation in WW observable calculation for readabilities sake.
- Add MCParticle print function.
- Use MCParticle print function for debugging in the WW processor.
- Fix bug in MCParticle print function.
- Correct WW Wl system observables comments.