### PR TITLE
Add single-W production

### DIFF
--- a/PrEWInputProduction/RKHelp/RKCoefMatcher.py
+++ b/PrEWInputProduction/RKHelp/RKCoefMatcher.py
@@ -13,13 +13,15 @@ class RKCoefMatcher:
     """
     
     MC_to_RK_names = {
-        "WW_muminus" : "WW_semilep_MuAntiNu",
-        "WW_muplus" : "WW_semilep_AntiMuNu"
+      "WW_muminus" : "WW_semilep_MuAntiNu",
+      "WW_muplus" : "WW_semilep_AntiMuNu",
+      "SingleW_eminus" : "singleWplussemileptonic",
+      "SingleW_eplus" : "singleWminussemileptonic"
     }
     
     RK_binning = {
-        "WW_semilep_MuAntiNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
-        "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"]
+      "WW_semilep_MuAntiNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
+      "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"]
     }
     
     # Sometimes binning is different (without affecting the cross section)

--- a/PrEWInputProduction/RKHelp/RKCoefMatcher.py
+++ b/PrEWInputProduction/RKHelp/RKCoefMatcher.py
@@ -21,7 +21,9 @@ class RKCoefMatcher:
     
     RK_binning = {
       "WW_semilep_MuAntiNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
-      "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"]
+      "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
+      "singleWplussemileptonic" : ["costh_Whad_star", "costh_e_star", "m_enu"],
+      "singleWminussemileptonic" : ["costh_Whad_star", "costh_e_star", "m_enu"]
     }
     
     # Sometimes binning is different (without affecting the cross section)

--- a/PrEWInputProduction/SingleW/SingleW.py
+++ b/PrEWInputProduction/SingleW/SingleW.py
@@ -1,0 +1,78 @@
+import ROOT
+import logging as log
+import math
+import sys
+
+# Local modules
+sys.path.append("../Core")
+import CreatePrEWInput as CPI
+sys.path.append("../IO")
+import InputHelpers as IH
+import OutputHelpers as OH
+sys.path.append("../ROOTHelp")
+import DistrHelpers as DH
+sys.path.append("../Systematics")
+import SystematicsOptions as SSO
+
+# ------------------------------------------------------------------------------
+
+def main():
+    """ Run the SingleW code for different cases.
+    """
+    log.basicConfig(level=log.WARNING) # Set logging level
+    ROOT.EnableImplicitMT() # Enable multithreading in RDataFrame
+    ROOT.gROOT.SetBatch(True) # Don't show graphics at runtime
+
+    # Input
+    tree_name = "SingleWObservables"
+    energy = 250
+    path_LR = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/4f_sW_sl_eL_pR.root"
+    path_RL = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/4f_sW_sl_eR_pL.root"
+    path_LL = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/4f_sW_sl_eL_pL.root"
+    path_RR = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/4f_sW_sl_eR_pR.root"
+    input_LR = IH.InputInfo(path_LR, tree_name, energy)
+    input_RL = IH.InputInfo(path_RL, tree_name, energy)
+    input_LL = IH.InputInfo(path_RL, tree_name, energy)
+    input_RR = IH.InputInfo(path_RL, tree_name, energy)
+    inputs_os = [input_LR, input_RL] # Opposite sign chirality infos
+
+    # Output settings
+    output_dir = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/PrEWInput"
+    create_plots = True
+
+    # Coordinates
+    coords = [
+        DH.Coordinate("costh_Whad_star", -0.9695290858725761, 0.9695290858725761),
+        DH.Coordinate("costh_e_star", 10, -0.925925925925926, 0.925925925925926),
+        DH.Coordinate("m_enu", 20, 4.037857055, 165.55213928499998),
+    ]
+
+    # Create distributions for opposite-sign chiralities (both charges)
+    for input in inputs_os:
+      CPI.create_PrEW_input(
+        input = input, coords = coords, 
+        output = OH.OutputInfo( output_dir, distr_name = "SingleW_eminus", create_plots = create_plots), 
+        cuts = "(e_charge == -1)")
+      CPI.create_PrEW_input(
+        input = input, coords = coords, 
+        output = OH.OutputInfo( output_dir, distr_name = "SingleW_eplus", create_plots = create_plots), 
+        cuts = "(e_charge == +1)")
+
+    # Create distributions for same-sign chiralities
+    CPI.create_PrEW_input(
+      input = input_RR, coords = coords, 
+      output = OH.OutputInfo( output_dir, distr_name = "SingleW_eminus", create_plots = create_plots), 
+      cuts = "(e_charge == -1)")
+    CPI.create_PrEW_input(
+      input = input_LL, coords = coords, 
+      output = OH.OutputInfo( output_dir, distr_name = "SingleW_eplus", create_plots = create_plots), 
+      cuts = "(e_charge == +1)")
+    
+    print("Done.")
+
+# ------------------------------------------------------------------------------
+
+# If this script is called directly (not imported), call the main funciton
+if __name__ == "__main__":
+    main()
+    

--- a/PrEWInputProduction/SingleW/SingleW.py
+++ b/PrEWInputProduction/SingleW/SingleW.py
@@ -32,8 +32,8 @@ def main():
     path_RR = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/4f_sW_sl/4f_sW_sl_eR_pR.root"
     input_LR = IH.InputInfo(path_LR, tree_name, energy)
     input_RL = IH.InputInfo(path_RL, tree_name, energy)
-    input_LL = IH.InputInfo(path_RL, tree_name, energy)
-    input_RR = IH.InputInfo(path_RL, tree_name, energy)
+    input_LL = IH.InputInfo(path_LL, tree_name, energy)
+    input_RR = IH.InputInfo(path_RR, tree_name, energy)
     inputs_os = [input_LR, input_RL] # Opposite sign chirality infos
 
     # Output settings

--- a/PrEWInputProduction/SingleW/SingleW.py
+++ b/PrEWInputProduction/SingleW/SingleW.py
@@ -42,7 +42,7 @@ def main():
 
     # Coordinates
     coords = [
-        DH.Coordinate("costh_Whad_star", -0.9695290858725761, 0.9695290858725761),
+        DH.Coordinate("costh_Whad_star", 20, -0.9695290858725761, 0.9695290858725761),
         DH.Coordinate("costh_e_star", 10, -0.925925925925926, 0.925925925925926),
         DH.Coordinate("m_enu", 20, 4.037857055, 165.55213928499998),
     ]

--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,13 @@ chmod u+x ./macros/*/*.sh
 ./macros/FullProduction/run_single_process.sh --process=4f_WW_sl --input-config=$(pwd)/scripts/config/input_250.config --output-config=$(pwd)/scripts/config/output_250.config
 ```
 
+Available processes are:
+
+Input name | Common name | Final state
+---|---|---
+4f_WW_sl  | Semileptonic W pair production | qq mu/tau nu 
+4f_sW_sl  | Semileptonic single-W production  | qq e nu
+
 ### How to create PrEW fit input
 
 Python code to convert the Marlin processor output into PrEW fit input is provided in the `PrEWInputProduction` directory.

--- a/scripts/examples/SingleWProcessorTest.xml
+++ b/scripts/examples/SingleWProcessorTest.xml
@@ -1,0 +1,33 @@
+<marlin>
+  
+  <execute>
+    <!-- List the processors to execute here ! -->
+    <processor name="MySingleWProcessor" />
+  </execute>
+  
+  <global>
+    <!-- Change the input file here or by command line -->
+    <parameter name="LCIOInputFiles"> 
+      /pnfs/desy.de/ilc/prod/ilc/mc-2020/generated/250-SetA/4f/E250-SetA.P4f_sw_sl.Gwhizard-2_8_5.eL.pR.I500106.0.slcio
+    </parameter>
+    <!-- The maximum number of events + runs to process -->
+    <parameter name="MaxRecordNumber" value="0"/>
+    <!-- The number of events to skip on start -->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <!-- Global verbosity -->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <!-- A user random seed -->
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+  
+  <!-- Your processor configuration here after -->
+  <processor name="MySingleWProcessor" type="SingleWProcessor">
+    <!-- The MC particle collection name -->
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="OutputFilePath"> 
+      /nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/Test/SingleWtest.root
+    </parameter>
+  </processor>
+  
+</marlin>

--- a/scripts/templates/4f_sW_sl.xml
+++ b/scripts/templates/4f_sW_sl.xml
@@ -1,0 +1,36 @@
+<marlin>
+  
+  <execute>
+    <!-- List the processors to execute here ! -->
+    <processor name="MySingleWProcessor" />
+  </execute>
+  
+  <global>
+    <!-- Change the input file here or by command line -->
+    <parameter name="LCIOInputFiles"> 
+      INPUT_FILE_TOKEN
+    </parameter>
+    <!-- The maximum number of events + runs to process -->
+    <parameter name="MaxRecordNumber" value="0"/>
+    <!-- The number of events to skip on start -->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <!-- Global verbosity -->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <!-- A user random seed -->
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+  
+  <!-- Your processor configuration here after -->
+  <processor name="MySingleWProcessor" type="SingleWProcessor">
+    <!-- The MC particle collection name -->
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="UnboostCrossingAngle"> 
+      UNBOOST_CROSSINGANGLE_TOKEN
+    </parameter>
+    <parameter name="OutputFilePath"> 
+      OUTPUT_FILE_TOKEN
+    </parameter>
+  </processor>
+  
+</marlin>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -10,6 +10,8 @@ include_directories( include )
 aux_source_directory( src/Utils SRC_FILES )
 aux_source_directory( src/WW SRC_FILES )
 aux_source_directory( src/WW/Processor SRC_FILES )
+aux_source_directory( src/SingleW SRC_FILES )
+aux_source_directory( src/SingleW/Processor SRC_FILES )
 add_shared_library( ${PROJECT_NAME} ${SRC_FILES} )
 
 # Link external libraries

--- a/source/include/SingleW/SingleWObservables.h
+++ b/source/include/SingleW/SingleWObservables.h
@@ -11,13 +11,13 @@ struct SingleWObservables {
   // Boost-independent observables
   int e_charge{};
 
-  // Observables in the leptonic W rest frame
-  // -> z axis should be along W flight direction
-  double phi_e_star{};
+  // Observables in the (outgoing) electron-neutrino rest frame
+  // -> z axis should be along combined flight direction
   double costh_e_star{};
 
   // Observables in the ee rest frame
   // -> Detector coordinate system (expecting no significant x-y boost)
+  double costh_Whad_star{};
   double m_enu{};
 
   // Observables in detector rest frame
@@ -26,8 +26,8 @@ struct SingleWObservables {
     /** Reset all observables to their default value.
      **/
     e_charge = 0;
-    phi_e_star = 9e9;
     costh_e_star = 9e9;
+    costh_Whad_star = 9e9;
     m_enu = 9e9;
   }
 };

--- a/source/include/SingleW/SingleWObservables.h
+++ b/source/include/SingleW/SingleWObservables.h
@@ -1,0 +1,37 @@
+#ifndef LIB_SINGLEW_SINGLEWOBSERVABLES_H
+#define LIB_SINGLEW_SINGLEWOBSERVABLES_H 1
+
+namespace SingleW {
+
+struct SingleWObservables {
+  /** Helper struct to keep all the variables that will be connected with the
+    *TTree branches in the SingleW analysis.
+   **/
+
+  // Boost-independent observables
+  int e_charge{};
+
+  // Observables in the leptonic W rest frame
+  // -> z axis should be along W flight direction
+  double phi_e_star{};
+  double costh_e_star{};
+
+  // Observables in the ee rest frame
+  // -> Detector coordinate system (expecting no significant x-y boost)
+  double m_enu{};
+
+  // Observables in detector rest frame
+
+  void reset() {
+    /** Reset all observables to their default value.
+     **/
+    e_charge = 0;
+    phi_e_star = 9e9;
+    costh_e_star = 9e9;
+    m_enu = 9e9;
+  }
+};
+
+} // namespace SingleW
+
+#endif

--- a/source/include/SingleW/SingleWProcessor.h
+++ b/source/include/SingleW/SingleWProcessor.h
@@ -96,7 +96,8 @@ private:
 
   void extract_observables(const EVENT::MCParticleVec &mcps);
   void extract_lab_observables(const EVENT::MCParticle &e);
-  void extract_ee_observables(const EVENT::MCParticle &W_enu);
+  void extract_ee_observables(const EVENT::MCParticle &W_enu,
+                              const EVENT::MCParticle &W_h);
   void extract_enu_observables(const EVENT::MCParticle &W_enu,
                                const EVENT::MCParticle &e);
 };

--- a/source/include/SingleW/SingleWProcessor.h
+++ b/source/include/SingleW/SingleWProcessor.h
@@ -1,0 +1,104 @@
+#ifndef LIB_SINGLEWPROCESSOR_H
+#define LIB_SINGLEWPROCESSOR_H 1
+
+#include <SingleW/SingleWObservables.h>
+#include <Utils/HeaderInfo.h>
+
+// Includes from iLCSoft
+#include "EVENT/MCParticle.h"
+#include "marlin/Processor.h"
+
+// Includes from ROOT
+#include <TFile.h>
+#include <TTree.h>
+
+// Standard library
+#include <memory>
+
+class SingleWProcessor : public marlin::Processor {
+public:
+  /**
+   *  @brief  Factory method to create a processor
+   *
+   *  This method is called internally by Marlin to create an instance of your
+   * processor
+   */
+  marlin::Processor *newProcessor() { return new SingleWProcessor(); }
+
+  /**
+   *  @brief  Constructor
+   *
+   *  Regiter your parameters in there. See SingleWProcessor.cc
+   */
+  SingleWProcessor();
+
+  // These two lines avoid frequent compiler warnings when using -Weffc++
+  SingleWProcessor(const SingleWProcessor &) = delete;
+  SingleWProcessor &operator=(const SingleWProcessor &) = delete;
+
+  /**
+   *  @brief  Called once at the begin of the job before anything is read.
+   *
+   *  Use to initialize the processor, e.g. book histograms. The parameters that
+   *  you have registered in the constructor are initialized
+   */
+  void init();
+
+  /**
+   *  Called for every run read from the file.
+   *
+   *  If you use simulation data output from ddsim (e.g from production data on
+   * grid), this will be called before the first event and only once in the job.
+   */
+  void processRunHeader(EVENT::LCRunHeader *run);
+
+  /**
+   *  @brief  Called for every event - the working horse.
+   *
+   *  Analyze your reconstructed particle objects from the event object here.
+   *  See SingleWProcessor.cc for an example
+   */
+  void processEvent(EVENT::LCEvent *event);
+
+  /**
+   *  @brief  Called after data processing for clean up.
+   *
+   *  You have allocated memory somewhere in your code ?
+   *  This is the best place to clean your mess !
+   */
+  void end();
+
+private:
+  // Initialize your members in the class definition to
+  // be more efficient and avoid compiler warnings
+
+  // --- Input parameters ------------------------------------------------------
+  std::string m_mcCollectionName = {""};
+
+  bool m_unboost_xangle{true};
+
+  std::string m_file_path{""};
+  std::string m_tree_name{""};
+
+  // ---------------------------------------------------------------------------
+
+  // TFile and TTree with result output
+  std::unique_ptr<TFile> m_file{};
+  TTree *m_tree{}; // Needs to be pure pointer, belongs to file
+
+  // Output information
+  Utils::HeaderInfo m_header{};
+  SingleW::SingleWObservables m_observables{};
+
+  // Internal functions
+  void create_tree();
+  void save_tree();
+
+  void extract_observables(const EVENT::MCParticleVec &mcps);
+  void extract_lab_observables(const EVENT::MCParticle &e);
+  void extract_ee_observables(const EVENT::MCParticle &W_enu);
+  void extract_enu_observables(const EVENT::MCParticle &W_enu,
+                               const EVENT::MCParticle &e);
+};
+
+#endif

--- a/source/src/SingleW/Processor/create_tree.cpp
+++ b/source/src/SingleW/Processor/create_tree.cpp
@@ -1,0 +1,21 @@
+#include <SingleW/SingleWProcessor.h>
+
+void SingleWProcessor::create_tree() {
+  /** Open the output file, create the needed TTree, create its branches and
+      connect them to the observable variables.
+   **/
+  // Open the output file
+  m_file = std::make_unique<TFile>(m_file_path.c_str(), "recreate");
+
+  // Create the tree
+  m_tree = new TTree(m_tree_name.c_str(), m_tree_name.c_str());
+
+  // Connect header info
+  m_header.connect(m_tree);
+
+  // Create and connect the observable branches
+  m_tree->Branch("e_charge", &m_observables.e_charge, "e_charge/I");
+  m_tree->Branch("phi_e_star", &m_observables.phi_e_star, "phi_e_star/D");
+  m_tree->Branch("costh_e_star", &m_observables.costh_e_star, "costh_e_star/D");
+  m_tree->Branch("m_enu", &m_observables.m_enu, "m_enu/D");
+}

--- a/source/src/SingleW/Processor/create_tree.cpp
+++ b/source/src/SingleW/Processor/create_tree.cpp
@@ -15,7 +15,7 @@ void SingleWProcessor::create_tree() {
 
   // Create and connect the observable branches
   m_tree->Branch("e_charge", &m_observables.e_charge, "e_charge/I");
-  m_tree->Branch("phi_e_star", &m_observables.phi_e_star, "phi_e_star/D");
   m_tree->Branch("costh_e_star", &m_observables.costh_e_star, "costh_e_star/D");
+  m_tree->Branch("costh_Whad_star", &m_observables.costh_Whad_star, "costh_Whad_star/D");
   m_tree->Branch("m_enu", &m_observables.m_enu, "m_enu/D");
 }

--- a/source/src/SingleW/Processor/extract_ee_observables.cpp
+++ b/source/src/SingleW/Processor/extract_ee_observables.cpp
@@ -1,23 +1,29 @@
-#include <Utils/MC.h>
 #include <SingleW/SingleWProcessor.h>
+#include <Utils/MC.h>
 
 // includes from MarlinHelp
 #include <MarlinHelp/ILD/Machine.h>
 
-void SingleWProcessor::extract_ee_observables(const EVENT::MCParticle &W_enu) {
+void SingleWProcessor::extract_ee_observables(const EVENT::MCParticle &W_enu,
+                                              const EVENT::MCParticle &W_h) {
   /** Extract the observables in the e+e- rest frame.
    **/
   // Lorentz vectors in lab frame
   auto enu_tlv_lab = Utils::MC::get_tlv(W_enu);
+  auto Wh_tlv_lab = Utils::MC::get_tlv(W_h);
 
   // Lorentz vectors in e+e- frame (after removing crossing angle)
   auto enu_tlv_ee = enu_tlv_lab;
+  auto Wh_tlv_ee = Wh_tlv_lab;
   if (m_unboost_xangle) {
     enu_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
         enu_tlv_lab, m_header.m_energy);
+    Wh_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+        Wh_tlv_lab, m_header.m_energy);
   }
 
   // --- Find observables ------------------------------------------------------
+  m_observables.costh_Whad_star = Wh_tlv_ee.CosTheta();
   m_observables.m_enu = enu_tlv_ee.M();
   // ---------------------------------------------------------------------------
 }

--- a/source/src/SingleW/Processor/extract_ee_observables.cpp
+++ b/source/src/SingleW/Processor/extract_ee_observables.cpp
@@ -1,0 +1,23 @@
+#include <Utils/MC.h>
+#include <SingleW/SingleWProcessor.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/ILD/Machine.h>
+
+void SingleWProcessor::extract_ee_observables(const EVENT::MCParticle &W_enu) {
+  /** Extract the observables in the e+e- rest frame.
+   **/
+  // Lorentz vectors in lab frame
+  auto enu_tlv_lab = Utils::MC::get_tlv(W_enu);
+
+  // Lorentz vectors in e+e- frame (after removing crossing angle)
+  auto enu_tlv_ee = enu_tlv_lab;
+  if (m_unboost_xangle) {
+    enu_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+        enu_tlv_lab, m_header.m_energy);
+  }
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.m_enu = enu_tlv_ee.M();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/SingleW/Processor/extract_enu_observables.cpp
+++ b/source/src/SingleW/Processor/extract_enu_observables.cpp
@@ -45,6 +45,5 @@ void SingleWProcessor::extract_enu_observables(const EVENT::MCParticle &W_enu,
 
   // --- Find observables ------------------------------------------------------
   m_observables.costh_e_star = e_tlv_enu_rot.CosTheta();
-  m_observables.phi_e_star = e_tlv_enu_rot.Phi();
   // ---------------------------------------------------------------------------
 }

--- a/source/src/SingleW/Processor/extract_enu_observables.cpp
+++ b/source/src/SingleW/Processor/extract_enu_observables.cpp
@@ -1,0 +1,50 @@
+#include <SingleW/SingleWProcessor.h>
+#include <Utils/MC.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/ILD/Machine.h>
+#include <MarlinHelp/Root/LorentzVec.h>
+
+void SingleWProcessor::extract_enu_observables(const EVENT::MCParticle &W_enu,
+                                               const EVENT::MCParticle &e) {
+  /** Extract the electron observables in the e-nu system.
+      Need angles in e-nu rest frame and with z' axis along e-nu combined flight
+      direction:
+      1. Boost into e+e- system after ISR
+      2. Rotate to be along enu axis
+      3. Boost into enu system
+      4. Extract angles
+   **/
+  // Lorentz vectors in lab frame
+  auto e_tlv_lab = Utils::MC::get_tlv(e);
+  auto enu_tlv_lab = Utils::MC::get_tlv(W_enu);
+
+  // Lorentz vectors in e+e- frame (after removing crossing angle)
+  auto energy = m_header.m_energy;
+  auto eM_tlv_ee = TLorentzVector(0, 0, energy, energy); // e- in z direction
+
+  auto e_tlv_ee = e_tlv_lab;
+  auto enu_tlv_ee = enu_tlv_lab;
+  if (m_unboost_xangle) {
+    e_tlv_ee =
+        MarlinHelp::ILD::Machine::unboost_crossing_angle(e_tlv_lab, energy);
+    enu_tlv_ee =
+        MarlinHelp::ILD::Machine::unboost_crossing_angle(enu_tlv_lab, energy);
+  }
+
+  // Rotate to be along e-nu flight direction (x in initial e- - e-nu plane,
+  // z along e-nu flight)
+  auto e_tlv_ee_rot = MarlinHelp::Root::LorentzVec::rotate_into(
+      e_tlv_ee, enu_tlv_ee, eM_tlv_ee);
+  auto enu_tlv_ee_rot = MarlinHelp::Root::LorentzVec::rotate_into(
+      enu_tlv_ee, enu_tlv_ee, eM_tlv_ee);
+
+  // Lorentz vectors in e-nu system
+  auto e_tlv_enu_rot =
+      MarlinHelp::Root::LorentzVec::boost_tlv(e_tlv_ee_rot, enu_tlv_ee_rot);
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_e_star = e_tlv_enu_rot.CosTheta();
+  m_observables.phi_e_star = e_tlv_enu_rot.Phi();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/SingleW/Processor/extract_lab_observables.cpp
+++ b/source/src/SingleW/Processor/extract_lab_observables.cpp
@@ -1,0 +1,10 @@
+#include <Utils/MC.h>
+#include <SingleW/SingleWProcessor.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/Root/LorentzVec.h>
+
+void SingleWProcessor::extract_lab_observables(const EVENT::MCParticle &/*e*/) {
+  /** Extract the observables in the lab/detector rest frame.
+   **/
+}

--- a/source/src/SingleW/Processor/extract_observables.cpp
+++ b/source/src/SingleW/Processor/extract_observables.cpp
@@ -1,0 +1,54 @@
+#include <SingleW/SingleWProcessor.h>
+#include <Utils/MC.h>
+
+// Includes from iLCSoft
+#include "streamlog/streamlog.h"
+
+void SingleWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
+  /** Extract the relevant generator level observables.
+   **/
+  // Find the first after-collision lepton (should be e-/e+)
+  // (skip the initial e+e- and ISR -> skip 8)
+  auto e = Utils::MC::find_first_lepton(mcps, 8);
+  streamlog_out(DEBUG) << "Found e: " << Utils::MC::print(*e) << std::endl;
+
+  if (!Utils::MC::is_e(*e)) {
+    throw std::domain_error("First found lepton isn't e, PDG: " +
+                            std::to_string(e->getPDG()));
+  }
+
+  m_observables.e_charge = int(e->getCharge());
+  if (Utils::MC::is_mu(*e))
+    m_observables.decay_to_mu = true;
+  if (Utils::MC::is_tau(*e))
+    m_observables.decay_to_tau = true;
+
+  // First try to see if W's are explicitely listed in MC list
+  auto W_enu = Utils::MC::find_first_W(mcps, m_observables.e_charge);
+  auto W_h = Utils::MC::find_first_W(mcps, -1 * m_observables.e_charge);
+
+  // If W's weren't explicitely found, look for their decay products
+  IMPL::MCParticleImpl W_enu_tech;
+  if (W_enu == NULL) {
+    W_enu_tech = Utils::MC::determine_W(mcps, m_observables.e_charge);
+    W_enu = &W_enu_tech;
+  }
+  IMPL::MCParticleImpl W_h_tech;
+  if (W_h == NULL) {
+    W_h_tech = Utils::MC::determine_W(mcps, -1 * m_observables.e_charge);
+    W_h = &W_h_tech;
+  }
+
+  streamlog_out(DEBUG) << "Found W_enu: " << Utils::MC::print(*W_enu)
+                       << std::endl;
+  streamlog_out(DEBUG) << "Found W_h: " << Utils::MC::print(*W_h) << std::endl;
+
+  // Extract observables in detector rest frame
+  this->extract_lab_observables(*e);
+
+  // Extract observables in ee rest frame
+  this->extract_ee_observables(*W_enu);
+
+  // Extract lepton angles in W_lep system
+  this->extract_Wl_observables(*W_enu, *e);
+}

--- a/source/src/SingleW/Processor/extract_observables.cpp
+++ b/source/src/SingleW/Processor/extract_observables.cpp
@@ -18,10 +18,6 @@ void SingleWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
   }
 
   m_observables.e_charge = int(e->getCharge());
-  if (Utils::MC::is_mu(*e))
-    m_observables.decay_to_mu = true;
-  if (Utils::MC::is_tau(*e))
-    m_observables.decay_to_tau = true;
 
   // First try to see if W's are explicitely listed in MC list
   auto W_enu = Utils::MC::find_first_W(mcps, m_observables.e_charge);
@@ -50,5 +46,5 @@ void SingleWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
   this->extract_ee_observables(*W_enu);
 
   // Extract lepton angles in W_lep system
-  this->extract_Wl_observables(*W_enu, *e);
+  this->extract_enu_observables(*W_enu, *e);
 }

--- a/source/src/SingleW/Processor/extract_observables.cpp
+++ b/source/src/SingleW/Processor/extract_observables.cpp
@@ -43,7 +43,7 @@ void SingleWProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
   this->extract_lab_observables(*e);
 
   // Extract observables in ee rest frame
-  this->extract_ee_observables(*W_enu);
+  this->extract_ee_observables(*W_enu, *W_h);
 
   // Extract lepton angles in W_lep system
   this->extract_enu_observables(*W_enu, *e);

--- a/source/src/SingleW/Processor/save_tree.cpp
+++ b/source/src/SingleW/Processor/save_tree.cpp
@@ -1,0 +1,14 @@
+#include <SingleW/SingleWProcessor.h>
+
+void SingleWProcessor::save_tree() {
+  /** Save the output tree and close the file.
+   **/
+  m_file->cd(); // go to output file
+  
+  streamlog_out(DEBUG) << "Writing tree." << std::endl; 
+  m_tree->Write();
+  
+  streamlog_out(DEBUG) << "Closing file." << std::endl; 
+  m_file->Close();
+   
+}

--- a/source/src/SingleW/SingleWProcessor.cc
+++ b/source/src/SingleW/SingleWProcessor.cc
@@ -1,0 +1,86 @@
+// -- your process header
+#include "SingleW/SingleWProcessor.h"
+
+// Custom headers
+#include <Utils/Collections.h>
+#include <Utils/MC.h>
+
+// -- lcio headers
+#include "EVENT/LCCollection.h"
+#include "UTIL/LCTOOLS.h"
+
+// This line allows to register your processor in marlin when calling "Marlin
+// steeringFile.xml"
+SingleWProcessor anSingleWProcessor;
+
+//------------------------------------------------------------------------------
+
+SingleWProcessor::SingleWProcessor() : marlin::Processor("SingleWProcessor") {
+  // _description comes from marlin::Processor
+  _description = "Processor for extracting the single-W (semilep) observables";
+
+  // Register an input collection
+  registerInputCollection(
+      LCIO::MCPARTICLE, // The collection type. Checkout the LCIO documentation
+                        // for other types
+      "MCParticleCollection", // The parameter name to read from steering file
+      "The Pandora PFO collection name", // A parameter description. Please fill
+                                         // this correctly
+      m_mcCollectionName, // Your variable to store the result after steering
+                          // file parsing
+      std::string("MCParticle")); // That's the default value, in case
+
+  // Register input parameters
+  registerProcessorParameter("UnboostCrossingAngle",
+                             "Should the crossing angle be unboosted?",
+                             m_unboost_xangle, bool(true));
+
+  registerProcessorParameter("OutputFilePath", "Path of the output ROOT file",
+                             m_file_path, std::string("./output.root"));
+  registerProcessorParameter("OutputTreeName", "Name of the output TTree",
+                             m_tree_name, std::string("SingleWObservables"));
+}
+
+//------------------------------------------------------------------------------
+
+void SingleWProcessor::init() {
+  // Usually a good idea to print parameters
+  printParameters(); // method from marlin::Processor
+
+  // Set up the output tree
+  this->create_tree();
+}
+
+//------------------------------------------------------------------------------
+
+void SingleWProcessor::processRunHeader(EVENT::LCRunHeader *run) {
+  streamlog_out(MESSAGE) << "Starting run no " << run->getRunNumber()
+                         << std::endl;
+  // LCRunHeader objects can be printed using LCTOOLS class
+  UTIL::LCTOOLS::dumpRunHeader(run);
+}
+
+//------------------------------------------------------------------------------
+
+void SingleWProcessor::processEvent(EVENT::LCEvent *event) {
+  streamlog_out(DEBUG) << "Processing event no " << event->getEventNumber()
+                       << " - run " << event->getEventNumber() << std::endl;
+
+  // Read the header info
+  m_header.read(*event);
+
+  // Reset the observables
+  m_observables.reset();
+
+  // Read the observables
+  auto mcps =
+      Utils::Collections::read<EVENT::MCParticle>(event, m_mcCollectionName);
+  this->extract_observables(mcps);
+
+  // Fill the event data into the tree
+  m_tree->Fill();
+}
+
+//------------------------------------------------------------------------------
+
+void SingleWProcessor::end() { this->save_tree(); }


### PR DESCRIPTION
- Add code for the single-W processor.
- Add code compilation for single-W processor to CMakeLists.
- Add example script for single-W processor.
- Add table of available processes to Readme.
- Fix bugs in single-W processor.
- Add single-W template Marlin script.
- Use the correct single-W observables in the single-W processor.
- Add a python script to create the PrEW input single-W distributions.
- Fix bug in single-W python script.
- Add single-W binning instruction to RK coef matching pyton macro.
- Fix Single-W python script bug.