### PR TITLE
Add 2-fermion code

### DIFF
--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -56,7 +56,7 @@ def create_PrEW_input(input, output, coords, cuts,
   if syst.use_muon_acc:
     muon_acc_cut = SMA.default_acc_cut()
     muon_acc = SMA.MuonAccParametrisation(rdf_after_cuts, muon_acc_cut, 0.001, 
-                                          "costh_l", output.distr_name, coords)
+                                          syst.costh_branch, output.distr_name, coords)
 
   # ----------------------- Trigger RDF operations -----------------------------
   log.debug("Triggering RDataFrame operations.")

--- a/PrEWInputProduction/Difermion/DifermionHadronic.py
+++ b/PrEWInputProduction/Difermion/DifermionHadronic.py
@@ -1,0 +1,75 @@
+import ROOT
+import logging as log
+import math
+import sys
+
+# Local modules
+sys.path.append("../Core")
+import CreatePrEWInput as CPI
+sys.path.append("../IO")
+import InputHelpers as IH
+import OutputHelpers as OH
+sys.path.append("../ROOTHelp")
+import DistrHelpers as DH
+
+# ------------------------------------------------------------------------------
+
+def main():
+    """ Run the hadronic difermion code for different cases.
+    """
+    n_threads = 10 # Number of threads to use 
+    
+    log.basicConfig(level=log.WARNING) # Set logging level
+    ROOT.EnableImplicitMT(n_threads) # Enable multithreading in RDataFrame
+    ROOT.gROOT.SetBatch(True) # Don't show graphics at runtime
+
+    # Input
+    tree_name = "DifermionObservables"
+    energy = 250
+    path_LR = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_h/2f_Z_h_eL_pR.root"
+    path_RL = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_h/2f_Z_h_eR_pL.root"
+    input_LR = IH.InputInfo(path_LR, tree_name, energy)
+    input_RL = IH.InputInfo(path_RL, tree_name, energy)
+    inputs = [input_LR, input_RL]
+
+    # Output settings
+    output_dir = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_h/PrEWInput"
+    create_plots = True
+
+    # Coordinates
+    coords = [
+        DH.Coordinate("costh_f_star", 20, -1.0, 1.0)
+    ]
+
+    # Different final states and the cuts that identify them
+    final_state_cuts = {
+      "uds" : "((f_pdg == 1) || (f_pdg == 2) || (f_pdg == 3))",
+      "c" : "(f_pdg == 4)",
+      "b" : "(f_pdg == 5)"
+    }
+    
+    # Mass ranges 
+    mass_cuts = [
+      [81, 101],
+      [180, 1.1*energy]
+    ]
+
+    # Create distributions for opposite-sign chiralities (both charges)
+    for input in inputs:
+      for final_state, fs_cut in final_state_cuts.items():
+        for m_low, m_high in mass_cuts:
+          distr_name = "2f_{}_{}to{}".format(final_state,int(m_low),int(m_high))
+          cuts = "{} && (m_ff > {}) && (m_ff < {})".format(fs_cut,m_low,m_high)
+          CPI.create_PrEW_input(
+            input = input, coords = coords, 
+            output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
+            cuts = cuts)
+
+    print("Done.")
+
+# ------------------------------------------------------------------------------
+
+# If this script is called directly (not imported), call the main funciton
+if __name__ == "__main__":
+    main()
+    

--- a/PrEWInputProduction/Difermion/DifermionLeptonic.py
+++ b/PrEWInputProduction/Difermion/DifermionLeptonic.py
@@ -1,0 +1,80 @@
+import ROOT
+import logging as log
+import math
+import sys
+
+# Local modules
+sys.path.append("../Core")
+import CreatePrEWInput as CPI
+sys.path.append("../IO")
+import InputHelpers as IH
+import OutputHelpers as OH
+sys.path.append("../ROOTHelp")
+import DistrHelpers as DH
+sys.path.append("../Systematics")
+import SystematicsOptions as SSO
+
+# ------------------------------------------------------------------------------
+
+def main():
+    """ Run the leptonic difermion code for different cases.
+    """
+    n_threads = 10 # Number of threads to use 
+    
+    log.basicConfig(level=log.WARNING) # Set logging level
+    ROOT.EnableImplicitMT(n_threads) # Enable multithreading in RDataFrame
+    ROOT.gROOT.SetBatch(True) # Don't show graphics at runtime
+
+    # Input
+    tree_name = "DifermionObservables"
+    energy = 250
+    path_LR = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_l/2f_Z_l_eL_pR.root"
+    path_RL = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_l/2f_Z_l_eR_pL.root"
+    input_LR = IH.InputInfo(path_LR, tree_name, energy)
+    input_RL = IH.InputInfo(path_RL, tree_name, energy)
+    inputs = [input_LR, input_RL]
+
+    # Output settings
+    output_dir = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_l/PrEWInput"
+    create_plots = True
+
+    # Coordinates
+    coords = [
+        DH.Coordinate("costh_f_star", 20, -1.0, 1.0)
+    ]
+
+    # Mass ranges 
+    mass_cuts = [
+      [81, 101],
+      [180, 1.1*energy]
+    ]
+    
+    # --- Muons (w/ systematics) ------------------------------------------------
+    for input in inputs:
+      for m_low, m_high in mass_cuts:
+        distr_name = "2f_mu_{}to{}".format(final_state,int(m_low),int(m_high))
+        cuts = "(f_pdg == 13) && (m_ff > {}) && (m_ff < {})".format(fs_cut,m_low,m_high)
+        CPI.create_PrEW_input(
+          input = input, coords = coords, 
+          output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
+          cuts = cuts, 
+          syst = SSO.SystematicsOptions(use_muon_acc=True,costh_branch=["costh_f","costh_fbar"]))
+        
+    # --- Taus (no systematics) ------------------------------------------------
+    for input in inputs:
+      for m_low, m_high in mass_cuts:
+        distr_name = "2f_tau_{}to{}".format(final_state,int(m_low),int(m_high))
+        cuts = "(f_pdg == 15) && (m_ff > {}) && (m_ff < {})".format(fs_cut,m_low,m_high)
+        CPI.create_PrEW_input(
+          input = input, coords = coords, 
+          output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
+          cuts = cuts)
+    
+    print("Done.")
+
+# ------------------------------------------------------------------------------
+
+# If this script is called directly (not imported), call the main funciton
+if __name__ == "__main__":
+    main()
+    

--- a/PrEWInputProduction/Difermion/DifermionLeptonic.py
+++ b/PrEWInputProduction/Difermion/DifermionLeptonic.py
@@ -52,8 +52,8 @@ def main():
     # --- Muons (w/ systematics) ------------------------------------------------
     for input in inputs:
       for m_low, m_high in mass_cuts:
-        distr_name = "2f_mu_{}to{}".format(final_state,int(m_low),int(m_high))
-        cuts = "(f_pdg == 13) && (m_ff > {}) && (m_ff < {})".format(fs_cut,m_low,m_high)
+        distr_name = "2f_mu_{}to{}".format(int(m_low),int(m_high))
+        cuts = "(f_pdg == 13) && (m_ff > {}) && (m_ff < {})".format(m_low,m_high)
         CPI.create_PrEW_input(
           input = input, coords = coords, 
           output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
@@ -63,8 +63,8 @@ def main():
     # --- Taus (no systematics) ------------------------------------------------
     for input in inputs:
       for m_low, m_high in mass_cuts:
-        distr_name = "2f_tau_{}to{}".format(final_state,int(m_low),int(m_high))
-        cuts = "(f_pdg == 15) && (m_ff > {}) && (m_ff < {})".format(fs_cut,m_low,m_high)
+        distr_name = "2f_tau_{}to{}".format(int(m_low),int(m_high))
+        cuts = "(f_pdg == 15) && (m_ff > {}) && (m_ff < {})".format(m_low,m_high)
         CPI.create_PrEW_input(
           input = input, coords = coords, 
           output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 

--- a/PrEWInputProduction/RKHelp/RKCoefMatcher.py
+++ b/PrEWInputProduction/RKHelp/RKCoefMatcher.py
@@ -15,15 +15,15 @@ class RKCoefMatcher:
     MC_to_RK_names = {
       "WW_muminus" : "WW_semilep_MuAntiNu",
       "WW_muplus" : "WW_semilep_AntiMuNu",
-      "SingleW_eminus" : "singleWplussemileptonic",
-      "SingleW_eplus" : "singleWminussemileptonic"
+      "SingleW_eminus" : "sW_semilep_eMinus",
+      "SingleW_eplus" : "sW_semilep_ePlus"
     }
     
     RK_binning = {
       "WW_semilep_MuAntiNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
       "WW_semilep_AntiMuNu" : ["costh_Wminus_star","costh_l_star","phi_l_star"],
-      "singleWplussemileptonic" : ["costh_Whad_star", "costh_e_star", "m_enu"],
-      "singleWminussemileptonic" : ["costh_Whad_star", "costh_e_star", "m_enu"]
+      "sW_semilep_eMinus" : ["costh_Whad_star", "costh_e_star", "m_enu"],
+      "sW_semilep_ePlus" : ["costh_Whad_star", "costh_e_star", "m_enu"]
     }
     
     # Sometimes binning is different (without affecting the cross section)
@@ -134,9 +134,10 @@ def default_coef_matcher():
     """ Get the default coef matcher that looks in all known RK distributions (at 250 GeV!!!).
     """
     matcher = RKCoefMatcher()
-    matcher.add_RK_file("/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/GlobalFit/UnifiedApproach/MinimizationProcessFiles/ROOTfiles/MinimizationProcessesListFile_500_250Full_Elektroweak_menu_2018_04_03.root", "MinimizationProcesses250GeV")
-    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root", "MinimizationProcesses250GeV")
-    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/MatrixElementDistributions/ww_sl0muq/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/MatrixElementDistributions/ww_sl0muq/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/MatrixElementDistributions/sw_sl0qq/distributions/combined/Distribution_250GeV_sW_semilep_eMinus.root", "MinimizationProcesses250GeV")
+    matcher.add_RK_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/MatrixElementDistributions/sw_sl0qq/distributions/combined/Distribution_250GeV_sW_semilep_ePlus.root", "MinimizationProcesses250GeV")
     return matcher
 
 # ------------------------------------------------------------------------------

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -20,8 +20,18 @@ def get_costh_cut(cut_val, center_shift, width_shift, costh_branch):
   cut_str = "({} > {}) && ({} < {})".format(costh_branch, neg_cut, costh_branch,
                                             pos_cut)
   return cut_str
-  
 
+def get_ndim_costh_cut(cut_val, center_shift, width_shift, costh_branches):
+  """ Applying the same cos(theta) cut to multiple branches (/particles) at the
+      same time. 
+  """
+  cut_str = ""
+  for costh_branch in costh_branches:
+    if cut_str != "":
+      cut_str += " && "  
+    cut_str += get_costh_cut(cut_val, center_shift, width_shift, costh_branch)
+  return cut_str
+  
 # ------------------------------------------------------------------------------
 
 def get_coef_data(hist_nocut, hist_0, hist_c, hist_2c, hist_w, hist_2w, hist_cw, 
@@ -104,19 +114,23 @@ class MuonAccParametrisation:
           The dataframe that can be used to extract the changes with the cuts.
           The initial cut value which is the same on both side (+-cos(theta)).
           The deviation that is used in the test to find the cut-dependence.
-          The name of the cos(Theta_muon) branch.
+          The name of the cos(Theta_muon) branch (can be string or array).
         And two histogram-related input (name and coordinate information).
     """
     self.cut_val = cut_val
     self.delta = delta
     
+    # Need branch(es) as array, and allow passing as string
+    if isinstance(costh_branch, str):
+      costh_branch = [costh_branch]
+    
     # Five different cuts are tested 
-    rdf_0 =  rdf.Filter(get_costh_cut(cut_val, 0, 0, costh_branch))
-    rdf_c =  rdf.Filter(get_costh_cut(cut_val, delta, 0, costh_branch))
-    rdf_2c = rdf.Filter(get_costh_cut(cut_val, 2*delta, 0, costh_branch))
-    rdf_w =  rdf.Filter(get_costh_cut(cut_val, 0, delta, costh_branch))
-    rdf_2w = rdf.Filter(get_costh_cut(cut_val, 0, 2*delta, costh_branch))
-    rdf_cw = rdf.Filter(get_costh_cut(cut_val, delta, delta, costh_branch))
+    rdf_0 =  rdf.Filter(get_ndim_costh_cut(cut_val, 0, 0, costh_branch))
+    rdf_c =  rdf.Filter(get_ndim_costh_cut(cut_val, delta, 0, costh_branch))
+    rdf_2c = rdf.Filter(get_ndim_costh_cut(cut_val, 2*delta, 0, costh_branch))
+    rdf_w =  rdf.Filter(get_ndim_costh_cut(cut_val, 0, delta, costh_branch))
+    rdf_2w = rdf.Filter(get_ndim_costh_cut(cut_val, 0, 2*delta, costh_branch))
+    rdf_cw = rdf.Filter(get_ndim_costh_cut(cut_val, delta, delta, costh_branch))
   
     self.histptr_nocut =  DH.get_hist_ptr(rdf, distr_name + "_nocut", coords)
     self.histptr_0 =  DH.get_hist_ptr(rdf_0, distr_name + "_0", coords)

--- a/PrEWInputProduction/Systematics/SystematicsOptions.py
+++ b/PrEWInputProduction/Systematics/SystematicsOptions.py
@@ -5,9 +5,10 @@ class SystematicsOptions:
       considered.
   """
   
-  def __init__(self, use_muon_acc=False):
+  def __init__(self, use_muon_acc=False, costh_branch="costh"):
     """ All the potential options can be set here and are turned off by default.
     """
     self.use_muon_acc = use_muon_acc
+    self.costh_branch = costh_branch # Can be str or array of str
     
 # ------------------------------------------------------------------------------

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -49,12 +49,12 @@ def main():
         input = input, coords = coords, 
         output = OH.OutputInfo( output_dir, distr_name = "WW_muminus", create_plots = create_plots), 
         cuts = "(decay_to_mu == 1) && (l_charge == -1)",
-        syst = SSO.SystematicsOptions(use_muon_acc=True))
+        syst = SSO.SystematicsOptions(use_muon_acc=True,costh_branch="costh_l"))
       CPI.create_PrEW_input(
         input = input, coords = coords, 
         output = OH.OutputInfo( output_dir, distr_name = "WW_muplus", create_plots = create_plots), 
         cuts = "(decay_to_mu == 1) && (l_charge == +1)",
-        syst = SSO.SystematicsOptions(use_muon_acc=True))
+        syst = SSO.SystematicsOptions(use_muon_acc=True,costh_branch="costh_l"))
       CPI.create_PrEW_input(
         input = input, coords = coords, 
         output = OH.OutputInfo( output_dir, distr_name = "WW_tauminus", create_plots = create_plots), 

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,8 @@ Available processes are:
 
 Input name | Common name | Final state
 ---|---|---
+2f_Z_l  | Di-lepton production | mu mubar / tau taubar 
+2f_Z_h  | Di-quark production | qq
 4f_WW_sl  | Semileptonic W pair production | qq mu/tau nu 
 4f_sW_sl  | Semileptonic single-W production  | qq e nu
 

--- a/macros/FullProduction/run_single_process.sh
+++ b/macros/FullProduction/run_single_process.sh
@@ -108,7 +108,7 @@ for e_pol in "${e_polarizations[@]}"; do
       condor_job_IDs+="${condor_job_output##* } "
       
       # Wait a little to not overload the condor scheduler
-      sleep 0.05s
+      sleep 0.01s
     done
     cd ${dir}
     

--- a/scripts/examples/2fHadronicProcessorTest.xml
+++ b/scripts/examples/2fHadronicProcessorTest.xml
@@ -1,0 +1,33 @@
+<marlin>
+  
+  <execute>
+    <!-- List the processors to execute here ! -->
+    <processor name="MyDifermionProcessor" />
+  </execute>
+  
+  <global>
+    <!-- Change the input file here or by command line -->
+    <parameter name="LCIOInputFiles"> 
+      /pnfs/desy.de/ilc/prod/ilc/mc-2020/generated/250-SetA/2f_hadronic_eL_pR/E250-SetA.P2f_z_h.Gwhizard-2_8_5.eL.pR.I500010.2910.slcio
+    </parameter>
+    <!-- The maximum number of events + runs to process -->
+    <parameter name="MaxRecordNumber" value="0"/>
+    <!-- The number of events to skip on start -->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <!-- Global verbosity -->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <!-- A user random seed -->
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+  
+  <!-- Your processor configuration here after -->
+  <processor name="MyDifermionProcessor" type="DifermionProcessor">
+    <!-- The MC particle collection name -->
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="OutputFilePath"> 
+      /nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/Test/2fHadronicTest.root
+    </parameter>
+  </processor>
+  
+</marlin>

--- a/scripts/templates/2f_Z_h.xml
+++ b/scripts/templates/2f_Z_h.xml
@@ -1,0 +1,36 @@
+<marlin>
+  
+  <execute>
+    <!-- List the processors to execute here ! -->
+    <processor name="MyDifermionProcessor" />
+  </execute>
+  
+  <global>
+    <!-- Change the input file here or by command line -->
+    <parameter name="LCIOInputFiles"> 
+      INPUT_FILE_TOKEN
+    </parameter>
+    <!-- The maximum number of events + runs to process -->
+    <parameter name="MaxRecordNumber" value="0"/>
+    <!-- The number of events to skip on start -->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <!-- Global verbosity -->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <!-- A user random seed -->
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+  
+  <!-- Your processor configuration here after -->
+  <processor name="MyDifermionProcessor" type="DifermionProcessor">
+    <!-- The MC particle collection name -->
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="UnboostCrossingAngle"> 
+      UNBOOST_CROSSINGANGLE_TOKEN
+    </parameter>
+    <parameter name="OutputFilePath"> 
+      OUTPUT_FILE_TOKEN
+    </parameter>
+  </processor>
+  
+</marlin>

--- a/scripts/templates/2f_Z_l.xml
+++ b/scripts/templates/2f_Z_l.xml
@@ -1,0 +1,36 @@
+<marlin>
+  
+  <execute>
+    <!-- List the processors to execute here ! -->
+    <processor name="MyDifermionProcessor" />
+  </execute>
+  
+  <global>
+    <!-- Change the input file here or by command line -->
+    <parameter name="LCIOInputFiles"> 
+      INPUT_FILE_TOKEN
+    </parameter>
+    <!-- The maximum number of events + runs to process -->
+    <parameter name="MaxRecordNumber" value="0"/>
+    <!-- The number of events to skip on start -->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <!-- Global verbosity -->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <!-- A user random seed -->
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+  
+  <!-- Your processor configuration here after -->
+  <processor name="MyDifermionProcessor" type="DifermionProcessor">
+    <!-- The MC particle collection name -->
+    <parameter name="MCParticleCollection" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="UnboostCrossingAngle"> 
+      UNBOOST_CROSSINGANGLE_TOKEN
+    </parameter>
+    <parameter name="OutputFilePath"> 
+      OUTPUT_FILE_TOKEN
+    </parameter>
+  </processor>
+  
+</marlin>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,6 +8,8 @@ include_directories( include )
 # called lib%(repository)s.so, that with be install in the lib directory
 # in the top level directory of your project 
 aux_source_directory( src/Utils SRC_FILES )
+aux_source_directory( src/Difermion SRC_FILES )
+aux_source_directory( src/Difermion/Processor SRC_FILES )
 aux_source_directory( src/WW SRC_FILES )
 aux_source_directory( src/WW/Processor SRC_FILES )
 aux_source_directory( src/SingleW SRC_FILES )

--- a/source/include/Difermion/DifermionObservables.h
+++ b/source/include/Difermion/DifermionObservables.h
@@ -1,0 +1,36 @@
+#ifndef LIB_DIFERMION_DIFERMIONOBSERVABLES_H
+#define LIB_DIFERMION_DIFERMIONOBSERVABLES_H 1
+
+namespace Difermion {
+
+struct DifermionObservables {
+  /** Helper struct to keep all the variables that will be connected with the
+    *TTree branches in the Difermion analysis.
+   **/
+
+  // Boost-independent observables
+  int f_pdg{};
+
+  // Observables in the ee rest frame
+  // -> Detector coordinate system (expecting no significant x-y boost)
+  double costh_f_star{};
+  double m_ff{};
+
+  // Observables in detector rest frame
+  double costh_f{};
+  double costh_fbar{};
+
+  void reset() {
+    /** Reset all observables to their default value.
+     **/
+    f_pdg = 0;
+    costh_f_star = 9e9;
+    m_ff = 9e9;
+    costh_f = 9e9;
+    costh_fbar = 9e9;
+  }
+};
+
+} // namespace Difermion
+
+#endif

--- a/source/include/Difermion/DifermionProcessor.h
+++ b/source/include/Difermion/DifermionProcessor.h
@@ -1,0 +1,104 @@
+#ifndef LIB_DIFERMIONPROCESSOR_H
+#define LIB_DIFERMIONPROCESSOR_H 1
+
+#include <Difermion/DifermionObservables.h>
+#include <Utils/HeaderInfo.h>
+
+// Includes from iLCSoft
+#include "EVENT/MCParticle.h"
+#include "marlin/Processor.h"
+
+// Includes from ROOT
+#include <TFile.h>
+#include <TTree.h>
+
+// Standard library
+#include <memory>
+
+class DifermionProcessor : public marlin::Processor {
+public:
+  /**
+   *  @brief  Factory method to create a processor
+   *
+   *  This method is called internally by Marlin to create an instance of your
+   * processor
+   */
+  marlin::Processor *newProcessor() { return new DifermionProcessor(); }
+
+  /**
+   *  @brief  Constructor
+   *
+   *  Regiter your parameters in there. See DifermionProcessor.cc
+   */
+  DifermionProcessor();
+
+  // These two lines avoid frequent compiler warnings when using -Weffc++
+  DifermionProcessor(const DifermionProcessor &) = delete;
+  DifermionProcessor &operator=(const DifermionProcessor &) = delete;
+
+  /**
+   *  @brief  Called once at the begin of the job before anything is read.
+   *
+   *  Use to initialize the processor, e.g. book histograms. The parameters that
+   *  you have registered in the constructor are initialized
+   */
+  void init();
+
+  /**
+   *  Called for every run read from the file.
+   *
+   *  If you use simulation data output from ddsim (e.g from production data on
+   * grid), this will be called before the first event and only once in the job.
+   */
+  void processRunHeader(EVENT::LCRunHeader *run);
+
+  /**
+   *  @brief  Called for every event - the working horse.
+   *
+   *  Analyze your reconstructed particle objects from the event object here.
+   *  See DifermionProcessor.cc for an example
+   */
+  void processEvent(EVENT::LCEvent *event);
+
+  /**
+   *  @brief  Called after data processing for clean up.
+   *
+   *  You have allocated memory somewhere in your code ?
+   *  This is the best place to clean your mess !
+   */
+  void end();
+
+private:
+  // Initialize your members in the class definition to
+  // be more efficient and avoid compiler warnings
+
+  // --- Input parameters ------------------------------------------------------
+  std::string m_mcCollectionName = {""};
+
+  bool m_unboost_xangle{true};
+
+  std::string m_file_path{""};
+  std::string m_tree_name{""};
+
+  // ---------------------------------------------------------------------------
+
+  // TFile and TTree with result output
+  std::unique_ptr<TFile> m_file{};
+  TTree *m_tree{}; // Needs to be pure pointer, belongs to file
+
+  // Output information
+  Utils::HeaderInfo m_header{};
+  Difermion::DifermionObservables m_observables{};
+
+  // Internal functions
+  void create_tree();
+  void save_tree();
+
+  void extract_observables(const EVENT::MCParticleVec &mcps);
+  void extract_lab_observables(const EVENT::MCParticle &f,
+                               const EVENT::MCParticle &fbar);
+  void extract_ee_observables(const EVENT::MCParticle &f,
+                              const EVENT::MCParticle &fbar);
+};
+
+#endif

--- a/source/include/Utils/MC.h
+++ b/source/include/Utils/MC.h
@@ -6,8 +6,8 @@
 
 // Includes from iLCSoft
 #include "lcio.h"
-#include <IMPL/MCParticleImpl.h>
 #include <EVENT/MCParticle.h>
+#include <IMPL/MCParticleImpl.h>
 
 // Standard library
 #include <string>
@@ -39,10 +39,14 @@ bool is_W_compatible(const EVENT::MCParticle &mcp1,
 EVENT::MCParticle *find_first(const EVENT::MCParticleVec &vec,
                               std::vector<int> pdg_ids, int skip = 0,
                               int end = -1);
+EVENT::MCParticle *find_first_fermion(const EVENT::MCParticleVec &vec,
+                                      int skip = 0, int end = -1);
 EVENT::MCParticle *find_first_lepton(const EVENT::MCParticleVec &vec,
                                      int skip = 0, int end = -1);
 EVENT::MCParticle *find_first_W(const EVENT::MCParticleVec &vec,
                                 int charge = 0);
+
+EVENT::MCParticle *find_anti_partner(const EVENT::MCParticle &mcp);
 // -----------------------------------------------------------------------------
 
 // --- Elements according to ILD conventions -----------------------------------
@@ -53,7 +57,7 @@ EVENT::MCParticle *incoming_eP_after_ISR(const EVENT::MCParticleVec &vec);
 
 // --- Create MCParticles ------------------------------------------------------
 IMPL::MCParticleImpl create_W(const EVENT::MCParticle &mcp1,
-                           const EVENT::MCParticle &mcp2);
+                              const EVENT::MCParticle &mcp2);
 // -----------------------------------------------------------------------------
 
 // --- Print out related -------------------------------------------------------

--- a/source/src/Difermion/DifermionProcessor.cc
+++ b/source/src/Difermion/DifermionProcessor.cc
@@ -1,0 +1,87 @@
+// -- your process header
+#include "Difermion/DifermionProcessor.h"
+
+// Custom headers
+#include <Utils/Collections.h>
+#include <Utils/MC.h>
+
+// -- lcio headers
+#include "EVENT/LCCollection.h"
+#include "UTIL/LCTOOLS.h"
+
+// This line allows to register your processor in marlin when calling "Marlin
+// steeringFile.xml"
+DifermionProcessor aDifermionProcessor;
+
+//------------------------------------------------------------------------------
+
+DifermionProcessor::DifermionProcessor()
+    : marlin::Processor("DifermionProcessor") {
+  // _description comes from marlin::Processor
+  _description = "Processor for extracting the difermion observables";
+
+  // Register an input collection
+  registerInputCollection(
+      LCIO::MCPARTICLE, // The collection type. Checkout the LCIO documentation
+                        // for other types
+      "MCParticleCollection", // The parameter name to read from steering file
+      "The Pandora PFO collection name", // A parameter description. Please fill
+                                         // this correctly
+      m_mcCollectionName, // Your variable to store the result after steering
+                          // file parsing
+      std::string("MCParticle")); // That's the default value, in case
+
+  // Register input parameters
+  registerProcessorParameter("UnboostCrossingAngle",
+                             "Should the crossing angle be unboosted?",
+                             m_unboost_xangle, bool(true));
+
+  registerProcessorParameter("OutputFilePath", "Path of the output ROOT file",
+                             m_file_path, std::string("./output.root"));
+  registerProcessorParameter("OutputTreeName", "Name of the output TTree",
+                             m_tree_name, std::string("DifermionObservables"));
+}
+
+//------------------------------------------------------------------------------
+
+void DifermionProcessor::init() {
+  // Usually a good idea to print parameters
+  printParameters(); // method from marlin::Processor
+
+  // Set up the output tree
+  this->create_tree();
+}
+
+//------------------------------------------------------------------------------
+
+void DifermionProcessor::processRunHeader(EVENT::LCRunHeader *run) {
+  streamlog_out(MESSAGE) << "Starting run no " << run->getRunNumber()
+                         << std::endl;
+  // LCRunHeader objects can be printed using LCTOOLS class
+  UTIL::LCTOOLS::dumpRunHeader(run);
+}
+
+//------------------------------------------------------------------------------
+
+void DifermionProcessor::processEvent(EVENT::LCEvent *event) {
+  streamlog_out(DEBUG) << "Processing event no " << event->getEventNumber()
+                       << " - run " << event->getEventNumber() << std::endl;
+
+  // Read the header info
+  m_header.read(*event);
+
+  // Reset the observables
+  m_observables.reset();
+
+  // Read the observables
+  auto mcps =
+      Utils::Collections::read<EVENT::MCParticle>(event, m_mcCollectionName);
+  this->extract_observables(mcps);
+
+  // Fill the event data into the tree
+  m_tree->Fill();
+}
+
+//------------------------------------------------------------------------------
+
+void DifermionProcessor::end() { this->save_tree(); }

--- a/source/src/Difermion/Processor/create_tree.cpp
+++ b/source/src/Difermion/Processor/create_tree.cpp
@@ -1,0 +1,22 @@
+#include <Difermion/DifermionProcessor.h>
+
+void DifermionProcessor::create_tree() {
+  /** Open the output file, create the needed TTree, create its branches and
+      connect them to the observable variables.
+   **/
+  // Open the output file
+  m_file = std::make_unique<TFile>(m_file_path.c_str(), "recreate");
+
+  // Create the tree
+  m_tree = new TTree(m_tree_name.c_str(), m_tree_name.c_str());
+
+  // Connect header info
+  m_header.connect(m_tree);
+
+  // Create and connect the observable branches
+  m_tree->Branch("f_pdg", &m_observables.f_pdg, "f_pdg/I");
+  m_tree->Branch("costh_f_star", &m_observables.costh_f_star, "costh_f_star/D");
+  m_tree->Branch("m_ff", &m_observables.m_ff, "m_ff/D");
+  m_tree->Branch("costh_f", &m_observables.costh_f, "costh_f/D");
+  m_tree->Branch("costh_fbar", &m_observables.costh_fbar, "costh_fbar/D");
+}

--- a/source/src/Difermion/Processor/extract_ee_observables.cpp
+++ b/source/src/Difermion/Processor/extract_ee_observables.cpp
@@ -1,0 +1,30 @@
+#include <Difermion/DifermionProcessor.h>
+#include <Utils/MC.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/ILD/Machine.h>
+
+void DifermionProcessor::extract_ee_observables(const EVENT::MCParticle &f,
+                                                const EVENT::MCParticle &fbar) {
+  /** Extract the observables in the e+e- rest frame.
+   **/
+  // Lorentz vectors in lab frame
+  auto f_tlv_lab = Utils::MC::get_tlv(f);
+  auto fbar_tlv_lab = Utils::MC::get_tlv(fbar);
+
+  // Lorentz vectors in e+e- frame (after removing crossing angle)
+  auto f_tlv_ee = f_tlv_lab;
+  auto fbar_tlv_ee = fbar_tlv_lab;
+  if (m_unboost_xangle) {
+    f_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+        f_tlv_lab, m_header.m_energy);
+    fbar_tlv_ee = MarlinHelp::ILD::Machine::unboost_crossing_angle(
+        fbar_tlv_lab, m_header.m_energy);
+  }
+  auto ffbar_tlv_ee = f_tlv_ee + fbar_tlv_ee;
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_f_star = f_tlv_ee.CosTheta();
+  m_observables.m_ff = ffbar_tlv_ee.M();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/Difermion/Processor/extract_lab_observables.cpp
+++ b/source/src/Difermion/Processor/extract_lab_observables.cpp
@@ -1,0 +1,15 @@
+#include <Difermion/DifermionProcessor.h>
+#include <Utils/MC.h>
+
+void DifermionProcessor::extract_lab_observables(
+    const EVENT::MCParticle &f, const EVENT::MCParticle &fbar) {
+  /** Extract the observables in the lab/detector rest frame.
+   **/
+  auto f_tlv_lab = Utils::MC::get_tlv(f);
+  auto fbar_tlv_lab = Utils::MC::get_tlv(fbar);
+  
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_f = f_tlv_lab.CosTheta();
+  m_observables.costh_fbar = fbar_tlv_lab.CosTheta();
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/Difermion/Processor/extract_observables.cpp
+++ b/source/src/Difermion/Processor/extract_observables.cpp
@@ -13,7 +13,7 @@ void DifermionProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
   // Find the first after-collision fermion
   // (skip the initial e+e- and ISR -> skip 8)
   auto f = Utils::MC::find_first_fermion(mcps, 8);
-  auto fbar = Utils::MC::find_anti_partner(f);
+  auto fbar = Utils::MC::find_anti_partner(*f);
   streamlog_out(DEBUG) << "Found f: " << Utils::MC::print(*f) << std::endl;
   streamlog_out(DEBUG) << "Found fbar: " << Utils::MC::print(*fbar)
                        << std::endl;

--- a/source/src/Difermion/Processor/extract_observables.cpp
+++ b/source/src/Difermion/Processor/extract_observables.cpp
@@ -12,11 +12,21 @@ void DifermionProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
    **/
   // Find the first after-collision fermion
   // (skip the initial e+e- and ISR -> skip 8)
-  auto f = Utils::MC::find_first_fermion(mcps, 8);
-  auto fbar = Utils::MC::find_anti_partner(*f);
-  streamlog_out(DEBUG) << "Found f: " << Utils::MC::print(*f) << std::endl;
-  streamlog_out(DEBUG) << "Found fbar: " << Utils::MC::print(*fbar)
-                       << std::endl;
+  auto f1 = Utils::MC::find_first_fermion(mcps, 8);
+  auto f2 = Utils::MC::find_anti_partner(*f1);
+  streamlog_out(DEBUG) << "Found f1: " << Utils::MC::print(*f1) << std::endl;
+  streamlog_out(DEBUG) << "Found f2: " << Utils::MC::print(*f2) << std::endl;
+
+  // Assign which one is a fermion and which an anti-fermion
+  auto f = f1;
+  auto fbar = f2;
+  if (f1->getPDG() < 0) {
+    streamlog_out(DEBUG) << "f1 is anti-fermion and f2 is fermion" << std::endl;
+    f = f2;
+    fbar = f1;
+  } else {
+    streamlog_out(DEBUG) << "f1 is fermion and f2 is anti-fermion" << std::endl;
+  }
 
   // Save fermion PDG ID
   m_observables.f_pdg = std::abs(f->getPDG());

--- a/source/src/Difermion/Processor/extract_observables.cpp
+++ b/source/src/Difermion/Processor/extract_observables.cpp
@@ -1,0 +1,29 @@
+#include <Difermion/DifermionProcessor.h>
+#include <Utils/MC.h>
+
+// Includes from iLCSoft
+#include "streamlog/streamlog.h"
+
+// Standard library
+#include <cmath>
+
+void DifermionProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
+  /** Extract the relevant generator level observables.
+   **/
+  // Find the first after-collision fermion
+  // (skip the initial e+e- and ISR -> skip 8)
+  auto f = Utils::MC::find_first_fermion(mcps, 8);
+  auto fbar = Utils::MC::find_anti_partner(f);
+  streamlog_out(DEBUG) << "Found f: " << Utils::MC::print(*f) << std::endl;
+  streamlog_out(DEBUG) << "Found fbar: " << Utils::MC::print(*fbar)
+                       << std::endl;
+
+  // Save fermion PDG ID
+  m_observables.f_pdg = std::abs(f->getPDG());
+
+  // Extract observables in detector rest frame
+  this->extract_lab_observables(*f, *fbar);
+
+  // Extract observables in ee rest frame
+  this->extract_ee_observables(*f, *fbar);
+}

--- a/source/src/Difermion/Processor/save_tree.cpp
+++ b/source/src/Difermion/Processor/save_tree.cpp
@@ -1,0 +1,14 @@
+#include <Difermion/DifermionProcessor.h>
+
+void DifermionProcessor::save_tree() {
+  /** Save the output tree and close the file.
+   **/
+  m_file->cd(); // go to output file
+  
+  streamlog_out(DEBUG) << "Writing tree." << std::endl; 
+  m_tree->Write();
+  
+  streamlog_out(DEBUG) << "Closing file." << std::endl; 
+  m_file->Close();
+   
+}

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -229,8 +229,8 @@ EVENT::MCParticle *MC::find_first(const EVENT::MCParticleVec &vec,
 
 //------------------------------------------------------------------------------
 
-EVENT::MCParticle *find_first_fermion(const EVENT::MCParticleVec &vec,
-                                      int skip = 0, int end = -1) {
+EVENT::MCParticle *MC::find_first_fermion(const EVENT::MCParticleVec &vec,
+                                      int skip, int end) {
   /** Return the first fermion (not specified if f or fbar) in the vector that
       fits any of the given IDs. Optional:
        - Skip the first N elements of the vector (e.g. to skip initial
@@ -285,7 +285,7 @@ EVENT::MCParticle *MC::find_first_W(const EVENT::MCParticleVec &vec,
 
 //------------------------------------------------------------------------------
 
-EVENT::MCParticle *find_anti_partner(const EVENT::MCParticle &mcp) {
+EVENT::MCParticle *MC::find_anti_partner(const EVENT::MCParticle &mcp) {
   /** Find the anti-partner (same parent, opposite sign PDG) to the given
    * particle.
    **/

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -237,7 +237,7 @@ EVENT::MCParticle *find_first_fermion(const EVENT::MCParticleVec &vec,
          particles).
        - End search at given particle (-1 means whole vector)
    **/
-  auto fermion_ids{};
+  std::vector<int> fermion_ids{};
   for (int i = 1; i < 17; i++) {
     fermion_ids.push_back(i);
     fermion_ids.push_back(-i);
@@ -289,7 +289,8 @@ EVENT::MCParticle *find_anti_partner(const EVENT::MCParticle &mcp) {
   /** Find the anti-partner (same parent, opposite sign PDG) to the given
    * particle.
    **/
-  return MC::find_first(mcp.getParents().at(0).getDaughters(), -1*mcp.getPDG());
+  return MC::find_first(mcp.getParents().at(0)->getDaughters(),
+                        {-1 * mcp.getPDG()});
 }
 
 //------------------------------------------------------------------------------

--- a/source/src/Utils/MC.cpp
+++ b/source/src/Utils/MC.cpp
@@ -50,8 +50,8 @@ bool MC::is_type(const EVENT::MCParticle &mcp, const std::vector<int> &ids_plus,
   }
   if ((sign == 0) || (sign == -1)) {
     ids.insert(ids.end(), ids_minus.begin(), ids_minus.end());
-  } 
-  if ((sign != 0) && (std::abs(sign) != 1)){
+  }
+  if ((sign != 0) && (std::abs(sign) != 1)) {
     throw std::invalid_argument("Looking for invalid sign: " +
                                 std::to_string(sign));
   }
@@ -229,6 +229,24 @@ EVENT::MCParticle *MC::find_first(const EVENT::MCParticleVec &vec,
 
 //------------------------------------------------------------------------------
 
+EVENT::MCParticle *find_first_fermion(const EVENT::MCParticleVec &vec,
+                                      int skip = 0, int end = -1) {
+  /** Return the first fermion (not specified if f or fbar) in the vector that
+      fits any of the given IDs. Optional:
+       - Skip the first N elements of the vector (e.g. to skip initial
+         particles).
+       - End search at given particle (-1 means whole vector)
+   **/
+  auto fermion_ids{};
+  for (int i = 1; i < 17; i++) {
+    fermion_ids.push_back(i);
+    fermion_ids.push_back(-i);
+  }
+  return MC::find_first(vec, fermion_ids, skip, end);
+}
+
+//------------------------------------------------------------------------------
+
 EVENT::MCParticle *MC::find_first_lepton(const EVENT::MCParticleVec &vec,
                                          int skip, int end) {
   /** Return the first lepton in the vector that fits any of the given IDs.
@@ -263,6 +281,15 @@ EVENT::MCParticle *MC::find_first_W(const EVENT::MCParticleVec &vec,
   }
 
   return MC::find_first(vec, ids);
+}
+
+//------------------------------------------------------------------------------
+
+EVENT::MCParticle *find_anti_partner(const EVENT::MCParticle &mcp) {
+  /** Find the anti-partner (same parent, opposite sign PDG) to the given
+   * particle.
+   **/
+  return MC::find_first(mcp.getParents().at(0).getDaughters(), -1*mcp.getPDG());
 }
 
 //------------------------------------------------------------------------------
@@ -371,11 +398,11 @@ IMPL::MCParticleImpl MC::create_W(const EVENT::MCParticle &mcp1,
 std::string MC::print(const EVENT::MCParticle &mcp) {
   /** Return a string of some vital information of the MC particle.
    **/
-  return std::string("E: ") + std::to_string(mcp.getEnergy()) + 
-        " Px: " + std::to_string(mcp.getMomentum()[0]) +
-        " Py: " + std::to_string(mcp.getMomentum()[1]) +
-        " Pz: " + std::to_string(mcp.getMomentum()[2]) +
-        " Charge: " + std::to_string(mcp.getCharge());
+  return std::string("E: ") + std::to_string(mcp.getEnergy()) +
+         " Px: " + std::to_string(mcp.getMomentum()[0]) +
+         " Py: " + std::to_string(mcp.getMomentum()[1]) +
+         " Pz: " + std::to_string(mcp.getMomentum()[2]) +
+         " Charge: " + std::to_string(mcp.getCharge());
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add some functions to the MC Utils that help searching the MC particles for fermions (generic).
- Add source code for a difermion processor.
- Add example difermion processor script.
- Fix bugs in MC Utils functions.
- Add difermion processor to CMakeLists.
- Add difermion info to Readme.
- Fix bug in Difermion observable extraction.
- Fix namespace bug in MC Utils.
- Add difermion template scripts.
- Add the python code to create the 2f hadronic distributions.
- Update paths in default coef matcher to use latest distribution coeffs (although they are only slightly better).
- Correctly assign which one is the fermion and which one the anti-fermion in the 2-fermion processor.
- Increase HTCondor submission speed.
- Allow multiple particle cos(theta) branches in the calculation of the coefficients for the systematical effect of a cos(theta) cut.
- Explicitely set the cos(theta) branch in the systematics options. 
- Adjust WW python script to explicit cos(theta) branch setting.
- Add python code to create leptonic difermion fit input distributions.
- Use subdirectories for HTCondor output to avoid overcrowded directories for processes with many files.
- Fix bug in leptonic 2f python code.