### PR TITLE
Additional cut tests for muon validation

### DIFF
--- a/PrEWInputProduction/Core/Conventions.py
+++ b/PrEWInputProduction/Core/Conventions.py
@@ -1,0 +1,31 @@
+# ------------------------------------------------------------------------------
+
+""" Naming conventions within this framework.
+"""
+
+# ------------------------------------------------------------------------------
+# File naming conventions
+
+def csv_file_name(distr_name, energy, eM_chirality, eP_chirality):
+    """ CSV filename convention for the distributions. 
+    """
+    eM_ID = ""
+    eP_ID = ""
+    
+    if (eM_chirality == -1):
+        eM_ID = "eL"
+    elif (eM_chirality == 1):
+        eM_ID = "eR"
+    else:
+        raise ValueError("Unknown e- chirality: {}".format(eM_chirality))
+        
+    if (eP_chirality == -1):
+        eP_ID = "pL"
+    elif (eP_chirality == 1):
+        eP_ID = "pR"
+    else:
+        raise ValueError("Unknown e+ chirality: {}".format(eP_chirality))
+      
+    return "{}_{}_{}{}".format(distr_name,energy,eM_ID,eP_ID)
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -56,7 +56,8 @@ def create_PrEW_input(input, output, coords, cuts,
   muon_acc = None
   if syst.use_muon_acc:
     muon_acc_cut = SMA.default_acc_cut()
-    muon_acc = SMA.MuonAccParametrisation(rdf_after_cuts, muon_acc_cut, 0.001, 
+    delta = SMA.default_delta()
+    muon_acc = SMA.MuonAccParametrisation(rdf_after_cuts, muon_acc_cut, delta, 
                                           syst.costh_branch, output.distr_name, coords)
 
   # ----------------------- Trigger RDF operations -----------------------------

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -106,7 +106,8 @@ def create_PrEW_input(input, output, coords, cuts,
   # Also validate the parametrisation.
   if muon_acc is not None:
     data = muon_acc.add_coefs_to_data(data)
-    muon_acc_validator.validate(data, output, output_base_name)
+    sig_scale = 1000.0 * cross_section/n_total # Test using 1ab^-1 statistics
+    muon_acc_validator.validate(data, sig_scale, output, output_base_name)
 
   # Create a pandas dataframe
   df = pd.DataFrame(data)

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -120,10 +120,10 @@ def create_PrEW_input(input, output, coords, cuts,
 
   # Attach metadata to beginning of file
   metadata = CSVM.CSVMetadata()
-  metadata.add("name", output.distr_name)
-  metadata.add("energy", input.energy)
-  metadata.add("e- chirality", eM_chi)
-  metadata.add("e+ chirality", eP_chi)
+  metadata["Name"] = output.distr_name
+  metadata["Energy"] = input.energy
+  metadata["e-Chirality"] = eM_chi
+  metadata["e+Chirality"] = eP_chi
 
   if muon_acc is not None:
     muon_acc.add_coefs_to_metadata(metadata)

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -105,11 +105,8 @@ def create_PrEW_input(input, output, coords, cuts,
   data = coef_matcher.add_coefs_to_data(output.distr_name, eM_chi, eP_chi, data)
 
   # Try extracting the differential coefficients for the muon acceptance box.
-  # Also validate the parametrisation.
   if muon_acc is not None:
     data = muon_acc.add_coefs_to_data(data)
-    sig_scale = 1000.0 * cross_section/n_total # Test using 1ab^-1 statistics
-    muon_acc_validator.validate(data, sig_scale, output, output_base_name)
 
   # Create a pandas dataframe
   df = pd.DataFrame(data)
@@ -127,8 +124,12 @@ def create_PrEW_input(input, output, coords, cuts,
 
   if muon_acc is not None:
     muon_acc.add_coefs_to_metadata(metadata)
+    muon_acc_validator.write_validation_data(data, output, output_base_name, 
+                                             metadata, n_total, cross_section)
 
+  # Attach the metadata to the data file
   metadata.write(file_path)
+  
   log.debug("Done with distribution.")
 
 # ------------------------------------------------------------------------------

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -106,7 +106,7 @@ def create_PrEW_input(input, output, coords, cuts,
   # Also validate the parametrisation.
   if muon_acc is not None:
     data = muon_acc.add_coefs_to_data(data)
-    muon_acc_validator.validate(data, output)
+    muon_acc_validator.validate(data, output, output_base_name)
 
   # Create a pandas dataframe
   df = pd.DataFrame(data)

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -91,6 +91,8 @@ def create_PrEW_input(input, output, coords, cuts,
   if (output.create_plots):
     log.debug("Create histogram plot.")
     DP.draw_hist(hist, output, output_base_name)
+    if muon_acc is not None:
+      muon_acc.plot_cut_result(output, output_base_name)
 
   # ----------------------- Producing PrEW input -------------------------------
   log.debug("Start producing PrEW input.")

--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -11,6 +11,7 @@ import pandas as pd
 import sys
 
 # Local modules
+import Conventions as Conv
 sys.path.append("../IO")
 import CSVMetadata as CSVM
 sys.path.append("../RKHelp")
@@ -73,8 +74,8 @@ def create_PrEW_input(input, output, coords, cuts,
       output.distr_name, n_total, n_after_cuts, n_after_cuts/n_total*100.0))
 
   # Base for output file name
-  output_base_name = DH.get_distr_filebase(output.distr_name, input.energy, 
-                                           eM_chi, eP_chi)
+  output_base_name = Conv.csv_file_name(output.distr_name, input.energy, 
+                                      eM_chi, eP_chi)
   output_base = "{}/{}".format(output.dir, output_base_name)
 
   # Correctly normalize the histogram

--- a/PrEWInputProduction/IO/CSVMetadata.py
+++ b/PrEWInputProduction/IO/CSVMetadata.py
@@ -3,27 +3,16 @@ class CSVMetadata:
     """
     begin_marker = "#BEGIN-METADATA"
     end_marker = "#END-METADATA"
-
-    marker_map = {
-        "name": "Name",
-        "energy": "Energy",
-        "e- chirality": "e-Chirality",
-        "e+ chirality": "e+Chirality"
-    }
-    
     coef_marker = "Coef"
 
     def __init__(self):
         self.metadata = {}
 
-    def add(self, name, value):
-        """ Add the given attribute metadata.
-        """
-        if not name in self.marker_map.keys():
-            raise ValueError(
-                "Unknown attribute {}, only know {}.", self.marker_map[name], self.marker_map.keys())
-        else:
-            self.metadata[self.marker_map[name]] = value
+    def __setitem__(self, index, value):
+        self.metadata[index] = value
+
+    def __getitem__(self, index):
+        return self.metadata[index]
             
     def add_coef(self, base_name, coef_name, value):
         """ Add a global coefficient as metadata.

--- a/PrEWInputProduction/ROOTHelp/DistrHelpers.py
+++ b/PrEWInputProduction/ROOTHelp/DistrHelpers.py
@@ -147,30 +147,6 @@ def get_data(root_hist, coords):
 
 # ------------------------------------------------------------------------------
 
-def get_distr_filebase(distr_name, energy, eM_chirality, eP_chirality):
-    """ Filename convention for the distributions. 
-    """
-    eM_ID = ""
-    eP_ID = ""
-    
-    if (eM_chirality == -1):
-        eM_ID = "eL"
-    elif (eM_chirality == 1):
-        eM_ID = "eR"
-    else:
-        raise ValueError("Unknown e- chirality: {}".format(eM_chirality))
-        
-    if (eP_chirality == -1):
-        eP_ID = "pL"
-    elif (eP_chirality == 1):
-        eP_ID = "pR"
-    else:
-        raise ValueError("Unknown e+ chirality: {}".format(eP_chirality))
-      
-    return "{}_{}_{}{}".format(distr_name,energy,eM_ID,eP_ID)
-
-# ------------------------------------------------------------------------------
-
 def get_hist_ptr_1d(rdf, distr_name, coords):
     """ Get TH1D histogram pointer. """
     th1_setup = ROOT.TH1D(distr_name, distr_name,

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -186,8 +186,14 @@ class MuonAccParametrisation:
     self.cut_deltas = [[],[]] # Cut values [[dcenter],[dwidth]]
     self.hist_ptrs = [] # Histograms at those cut values
     d_vals = np.array([-1.5, -1, -0.5, 0, 0.5, 1, 1.5])*delta
+    d_max = 1.5*delta * 1.001 # *1.001 for numerical uncertainty
     for dc in d_vals:
       for dw in d_vals:
+        # Restrict to a circle of 1.5 to avoid too much weight on outer points
+        if np.sqrt(dc**2 + dw**2) > d_max:
+          continue
+        
+        # Set up the cut test
         self.cut_deltas[0].append(dc)
         self.cut_deltas[1].append(dw)
         rdf_cut = rdf.Filter(get_ndim_costh_cut(cut_val, dc, dw, costh_branch))

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -173,4 +173,9 @@ def default_acc_cut():
   """
   return 0.95
 
+def default_delta():
+  """ Define the default delta variation used to calculate the cut dependence.
+  """
+  return 0.001
+
 # ------------------------------------------------------------------------------

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -17,8 +17,8 @@ def get_costh_cut(cut_val, center_shift, width_shift, costh_branch):
         The change that of the acceptance width (width_shift).
         The name of the cos(Theta) branch.
   """
-  pos_cut =   abs(cut_val) + center_shift + width_shift
-  neg_cut = - abs(cut_val) + center_shift - width_shift  
+  pos_cut =   abs(cut_val) + center_shift + width_shift/2.0
+  neg_cut = - abs(cut_val) + center_shift - width_shift/2.0
   cut_str = "({} > {}) && ({} < {})".format(costh_branch, neg_cut, costh_branch,
                                             pos_cut)
   return cut_str

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -315,7 +315,7 @@ class MuonAccParametrisation:
 def default_acc_cut():
   """ Define the default acceptance cut for the muon acceptance box.
   """
-  return 0.95
+  return 0.9925 # ~ 7 degrees
 
 def default_delta():
   """ Define the default delta variation used to calculate the cut dependence.

--- a/PrEWInputProduction/Systematics/MuonAcceptance.py
+++ b/PrEWInputProduction/Systematics/MuonAcceptance.py
@@ -145,7 +145,7 @@ class MuonAccParametrisation:
         Details are not described here (probably in PrEW, else in thesis).
         Coefficients are added to data.
     """
-    hist_nocut = self.histptr_0.GetValue()
+    hist_nocut = self.histptr_nocut.GetValue()
     hist_0 =  self.histptr_0.GetValue()
     hist_c =  self.histptr_c.GetValue()
     hist_2c = self.histptr_2c.GetValue()

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -113,9 +113,9 @@ class MuonAccValidator:
       costh_branch = [costh_branch]
     
     # Delta-center, Delta-width combinations to test
-    self.dc_tests = [-5, -2.5, -1, -0.5, 0, 0.5, 1, 2.5, 5]
-    self.dw_tests = [-5, -2.5, -1, -0.5, 0, 0.5, 1, 2.5, 5]
-    self.d_max = 5 # Maximum dc+dw value that will be tested
+    self.dc_tests = [-4, -2, -1, -0.5, 0, 0.5, 1, 2, 4]
+    self.dw_tests = [-4, -2, -1, -0.5, 0, 0.5, 1, 2, 4]
+    self.d_max = 4 # Maximum dc+dw value that will be tested
     self.test_vals = []
     for dc in self.dc_tests:
       for dw in self.dw_tests:

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -178,10 +178,9 @@ class MuonAccValidator:
         
         par_content = factor*hist_nocuts.GetBinContent(bin) 
         true_content = hist.GetBinContent(bin)
-        nocut_content = hist_nocuts.GetBinContent(bin)
         
         # Determine the relative difference caused by using the parametrisation
-        rel_diff = (par_content - true_content) / (nocut_content - true_content) if abs(nocut_content - true_content) > 0 else 0
+        rel_diff = (par_content - true_content) / true_content if true_content > 0 else 0
         hist_diff.SetBinContent(bin, rel_diff)
         
         # Detemine the significance of the difference
@@ -205,7 +204,7 @@ class MuonAccValidator:
     canvas_diff.cd()
     stack_diff.Draw("AP") # Is TMultiGraph, doesn't need "nostack"
     stack_diff.GetXaxis().SetTitle(self.coords[0].name)
-    stack_diff.GetYaxis().SetTitle("(N_{param}-N_{cut})/(N_{no cut}-N_{cut})")
+    stack_diff.GetYaxis().SetTitle("(N_{param}-N_{cut})/N_{cut}")
     
     canvas_sig = ROOT.TCanvas("c_{}".format(stack_name_sig))
     canvas_sig.cd()

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -81,16 +81,16 @@ class MuonAccValidator:
       costh_branch = [costh_branch]
     
     # Delta-center, Delta-width combinations to test
-    self.dc_tests = [-5, -3, -1, -0.5, 0, 0.5, 1, 3, 5]
-    self.dw_tests = [-5, -3, -1, -0.5, 0, 0.5, 1, 3, 5]
-    self.dc_min = np.amin(self.dc_tests)
-    self.dc_max = np.amax(self.dc_tests)
-    self.dw_min = np.amin(self.dw_tests)
-    self.dw_max = np.amax(self.dw_tests)
+    self.dc_tests = [-5, -2.5, -1, -0.5, 0, 0.5, 1, 2.5, 5]
+    self.dw_tests = [-5, -2.5, -1, -0.5, 0, 0.5, 1, 2.5, 5]
+    self.d_max = 5 # Maximum dc+dw value that will be tested
     self.test_vals = []
     for dc in self.dc_tests:
       for dw in self.dw_tests:
-        self.test_vals.append([dc*delta,dw*delta])
+        if abs(dc) + abs(dw) > self.d_max+0.01:
+          continue
+        else:
+          self.test_vals.append([dc*delta,dw*delta])
         
     # Create the needed ROOT colors
     self.colors = []
@@ -105,8 +105,7 @@ class MuonAccValidator:
         Sign is not considered, only absolute deviation from 0.
     """
     d_total = (abs(dc)+abs(dw)) / self.delta
-    d_max = np.amax([abs(self.dc_max),abs(self.dc_min)]) + np.amax([abs(self.dw_max),abs(self.dw_min)])
-    return d_total/d_max
+    return d_total/self.d_max
 
   def get_color_index(self, dc, dw):
     """ Translate the devation into a (custom) ROOT color index.

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -163,8 +163,8 @@ class MuonAccValidator:
       test.evaluate(coef_data, hist_nocuts)
       
       # Save the tested values
-      val_data["Delta-c"] = test.delta_c
-      val_data["Delta-w"] = test.delta_w
+      val_data["Delta-c"].append(test.delta_c)
+      val_data["Delta-w"].append(test.delta_w)
       
       # Get all the bin values from the histogram
       for i_bin in range(n_bins):

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -150,7 +150,7 @@ class MuonAccValidator:
     stack_name_diff = "{}_rel_diff".format(stack_name_base)
     stack_name_sig = "{}_sig".format(stack_name_base)
 
-    stack_diff = ROOT.THStack(stack_name_diff, stack_name_diff)
+    stack_diff = ROOT.TMultiGraph(stack_name_diff, stack_name_diff)
     stack_sig = ROOT.THStack(stack_name_sig, stack_name_sig)
 
     for test in self.tests:
@@ -182,7 +182,7 @@ class MuonAccValidator:
         nocut_content = hist_nocuts.GetBinContent(bin)
         
         # Determine the relative difference caused by using the parametrisation
-        rel_diff = abs(par_content - true_content) / abs(nocut_content - true_content) if abs(nocut_content - true_content) > 0 else 0
+        rel_diff = (par_content - true_content) / (nocut_content - true_content) if abs(nocut_content - true_content) > 0 else 0
         hist_diff.SetBinContent(bin, rel_diff)
         
         # Detemine the significance of the difference
@@ -191,19 +191,22 @@ class MuonAccValidator:
         
         i += 1 # Increment bin index without under/over-flow
       
+      # Convert diff histogram to graf (because contains negative values)
+      graph_diff = ROOT.TGraph(hist_diff)
+      
       color = self.get_color_index(test.delta_c,test.delta_w)
-      hist_diff.SetLineColor(color)
+      graph_diff.SetMarkerColor(color)
       hist_sig.SetLineColor(color)
       
-      stack_diff.Add(hist_diff, "hist")
+      stack_diff.Add(graph_diff)
       stack_sig.Add(hist_sig, "hist")
     
     # Draw and save the two stacks
     canvas_diff = ROOT.TCanvas("c_{}".format(stack_name_diff))
     canvas_diff.cd()
-    stack_diff.Draw("nostack")
+    stack_diff.Draw("AP") # Is TMultiGraph, doesn't need "nostack"
     stack_diff.GetXaxis().SetTitle(self.coords[0].name)
-    stack_diff.GetYaxis().SetTitle("|N_{param}-N_{cut}|/|N_{cut}-N_{no cut}|")
+    stack_diff.GetYaxis().SetTitle("(N_{param}-N_{cut})/(N_{no cut}-N_{cut})")
     
     canvas_sig = ROOT.TCanvas("c_{}".format(stack_name_sig))
     canvas_sig.cd()

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -1,0 +1,146 @@
+# ------------------------------------------------------------------------------
+
+""" Code to validate the Muon acceptance parametrisation.
+"""
+
+# ------------------------------------------------------------------------------
+
+import logging as log
+import numpy as np
+import ROOT
+import sys
+
+# Local modules
+sys.path.append("../IO")
+import OutputHelpers as OH
+sys.path.append("../ROOTHelp")
+import DistrHelpers as DH
+import DistrPlotting as DP
+sys.path.append("../Systematics")
+import MuonAcceptance as SMA
+
+# ------------------------------------------------------------------------------
+
+def muon_acc_factor(k_0, k_c, k_w, k_c2, k_w2, k_cw, delta_c, delta_w):
+  """ Return the factor by which a bin needs to be multiplied, given all the 
+      needed coefficients and the deviations in center and width.
+  """
+  return k_0 + k_c * delta_c + k_w * delta_w \
+         + k_c2 * delta_c**2 + k_w2 * delta_w**2 \
+         + k_cw * delta_c * delta_w 
+  
+def binned_muon_acc_factors(coef_data, delta_c, delta_w):
+  """ Get the binned factors (to multiple histogram bins with) for the given 
+      coefficients and given changes in central and width values.
+  """
+  
+  # Extract binned coefficients
+  k_0 = np.array(coef_data["Coef:MuonAcc_k0"])
+  k_c = np.array(coef_data["Coef:MuonAcc_kc"])
+  k_w = np.array(coef_data["Coef:MuonAcc_kw"])
+  k_c2 = np.array(coef_data["Coef:MuonAcc_kc2"])
+  k_w2 = np.array(coef_data["Coef:MuonAcc_kw2"])
+  k_cw = np.array(coef_data["Coef:MuonAcc_kcw"])
+  
+  return muon_acc_factor(k_0, k_c, k_w, k_c2, k_w2, k_cw, delta_c, delta_w)
+
+# ------------------------------------------------------------------------------
+
+class SingleCutTest:
+  """ Storage class for everything needed to test a single cut value.
+  """
+  
+  def __init__(self, rdf, cut_val, delta_c, delta_w, costh_branch, distr_name, coords):
+    rdf_filtered = rdf.Filter(SMA.get_ndim_costh_cut(cut_val, delta_c, delta_w, costh_branch))
+    cut_distr_name = "{}_dc{}_dw{}".format(distr_name, delta_c, delta_w)
+    self.hist_ptr =  DH.get_hist_ptr(rdf_filtered, cut_distr_name, coords)
+
+    self.delta_c = delta_c # Cut values
+    self.delta_w = delta_w
+
+# ------------------------------------------------------------------------------
+
+class MuonAccValidator:
+  """ Class that performs tests of the validity of the muon acceptance 
+      parametrisation.
+  """
+  
+  def __init__(self, rdf, cut_val, delta, costh_branch, distr_name, coords):
+    """ Essentially the same as muon acceptance calculation itself, uses way 
+        more points to test.
+    """
+    self.cut_val = cut_val
+    self.delta = delta
+    self.distr_name = distr_name
+    
+    # Need branch(es) as array, and allow passing as string
+    if isinstance(costh_branch, str):
+      costh_branch = [costh_branch]
+    
+    # Delta-center, Delta-width combinations to test
+    test_vals = []
+    for dc in [-10, -3, -1, -0.5, 0, 0.5, 1, 3, 10]:
+      for dw in [-10, -3, -1, -0.5, 0, 0.5, 1, 3, 10]:
+        test_vals.append([dc*delta,dw*delta])
+    
+    # Set up tests
+    self.tests = [SingleCutTest(rdf, cut_val, delta_c, delta_w, costh_branch, distr_name, coords) for delta_c, delta_w in test_vals]
+    self.histptr_nocut =  DH.get_hist_ptr(rdf, distr_name + "_nocut_val", coords)
+    
+  def validate(self, coef_data, output, extensions=["pdf","root"]):
+    """ Create plots to test the validity of the MuonAcceptance parametrisation 
+        and its coefficients.
+    """
+
+    hist_nocuts = self.histptr_nocut.GetPtr()
+    if not hist_nocuts.GetDimension() == 1:
+      log.error("Validation plots not implemented for histograms with dim != 1")
+      return
+
+    stack_name = "{}_stack".format(self.distr_name)
+    canvas = ROOT.TCanvas("c_{}".format(stack_name))
+    canvas.cd()
+    stack = ROOT.THStack(stack_name, stack_name)
+
+    for test in self.tests:
+      hist = test.hist_ptr.GetPtr()
+      hist_diff = hist_nocuts.Clone()
+      hist_diff.SetName("{}_scaling".format(hist.GetName()))
+      factors = binned_muon_acc_factors(coef_data, test.delta_c, test.delta_w)
+      
+      i = 0 # bin index not including under/over-flow
+      for bin in DH.get_bin_range(hist_diff):
+        # Skip overflow and underflow bins
+        if hist_diff.IsBinUnderflow(bin) or hist_diff.IsBinOverflow(bin): 
+          continue
+        
+        # Determine the factor for the bin (caused by the cut)  
+        factor = factors[i]
+        if factor > 1:
+          factor = 1
+        elif factor < 0:
+          factor = 0
+        
+        # Determine the relative difference caused by using the parametrisation
+        par_content = factor*hist_nocuts.GetBinContent(bin) 
+        true_content = hist.GetBinContent(bin)
+        nocut_content = hist_nocuts.GetBinContent(bin)
+        
+        rel_sig = abs(par_content - true_content) / abs(nocut_content - true_content) if abs(nocut_content - true_content) > 0 else 0
+        hist_diff.SetBinContent(bin, rel_sig)
+        
+        i += 1 # Increment bin index without under/over-flow
+      
+      stack.Add(hist_diff)
+    
+    stack.Draw("nostack")
+    
+    for extension in extensions:
+      # Create the plot subdirectory
+      plot_subdir = "{}/plots/{}".format(output.dir,extension)
+      OH.create_dir(plot_subdir)
+      
+      # Save the histogram
+      canvas.Print("{}/{}.{}".format(plot_subdir, stack_name, extension))
+
+# ------------------------------------------------------------------------------

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -87,7 +87,7 @@ class MuonAccValidator:
     self.test_vals = []
     for dc in self.dc_tests:
       for dw in self.dw_tests:
-        if abs(dc) + abs(dw) > self.d_max+0.01:
+        if np.sqrt(dc**2+dw**2) > self.d_max+0.001:
           continue
         else:
           self.test_vals.append([dc*delta,dw*delta])
@@ -101,10 +101,10 @@ class MuonAccValidator:
     self.histptr_nocut =  DH.get_hist_ptr(rdf, distr_name + "_nocut_val", coords)
 
   def get_d_norm(self, dc, dw):
-    """ Get normalized sum of dc and dw.
+    """ Get normalized root-of-squares sum of dc and dw.
         Sign is not considered, only absolute deviation from 0.
     """
-    d_total = (abs(dc)+abs(dw)) / self.delta
+    d_total = np.sqrt(dc**2+dw**2) / self.delta
     return d_total/self.d_max
 
   def get_color_index(self, dc, dw):
@@ -116,7 +116,7 @@ class MuonAccValidator:
   def create_colors(self):
     """ Create all the necessary ROOT TColors.
     """
-    colormap = cm.get_cmap("inferno") # Get a matplot lib color map
+    colormap = cm.get_cmap("plasma") # Get a matplot lib color map
     indices = []
     for test_val in self.test_vals:
       c_i = self.get_color_index(test_val[0],test_val[1])
@@ -131,7 +131,7 @@ class MuonAccValidator:
       c_name = "NewColor{}".format(c_i)
       self.colors.append(ROOT.TColor(c_i, c_r, c_g, c_b, c_name))
     
-  def validate(self, coef_data, sig_scale, output, base_name, extensions=["pdf","root"]):
+  def validate(self, coef_data, sig_scale, output, base_name, extensions=["pdf","png","root"]):
     """ Create plots to test the validity of the MuonAcceptance parametrisation 
         and its coefficients.
         Requires a "significance scale" which correctly scales the histograms

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -205,7 +205,7 @@ class MuonAccValidator:
       if dim > 1: 
         bin_center.append(hist_0.GetYaxis().GetBinCenter(bin_xyz[1]))
       if dim > 2:
-        bin_center.append(hist_0.GetYaxis().GetBinCenter(bin_xyz[2]))
+        bin_center.append(hist_0.GetZaxis().GetBinCenter(bin_xyz[2]))
       bin_centers.append(bin_center)
 
     # Attach metadata to beginning of file

--- a/PrEWInputProduction/Validation/MuonAccValidation.py
+++ b/PrEWInputProduction/Validation/MuonAccValidation.py
@@ -5,21 +5,18 @@
 
 # ------------------------------------------------------------------------------
 
-from array import array
 import ctypes
 import logging as log
-from matplotlib import cm
-from matplotlib.colors import ListedColormap, LinearSegmentedColormap
 import numpy as np
-import ROOT
+import pandas as pd
 import sys
 
 # Local modules
 sys.path.append("../IO")
+import CSVMetadata as CSVM
 import OutputHelpers as OH
 sys.path.append("../ROOTHelp")
 import DistrHelpers as DH
-import DistrPlotting as DP
 sys.path.append("../Systematics")
 import MuonAcceptance as SMA
 
@@ -50,40 +47,6 @@ def binned_muon_acc_factors(coef_data, delta_c, delta_w):
 
 # ------------------------------------------------------------------------------
 
-class SingleBinTest:
-  """ Class that for the calculation of validation measures for a single 
-      N-dimensional bin.
-  """
-  
-  def __init__(self, bin_center, val_cut, val_par, val_cut0):
-    """ val_cut  -> True influence of this cut
-        val_par  -> Influence as taken from the parametrisation
-        val_cut0 -> Value for the cut without varying the edges
-    """
-    self.bin_center = bin_center
-    self.val_cut = val_cut
-    self.val_par = val_par
-    self.val_cut0 = val_cut0
-        
-  def relative_deviation(self):
-    """ Return the relative deviation caused by the parametrisation.
-    """
-    return (self.val_par - self.val_cut) / self.val_cut if self.val_cut > 0 else 0
-    
-  def deviation_significance(self):
-    """ Return the (Poissonian) significance of deviation caused by the 
-        parametrisation.
-    """
-    return abs(self.val_par - self.val_cut) / np.sqrt(self.val_cut) if abs(self.val_cut) > 0 else 0
-    
-  def deviation_relevance(self):
-    """ Return the relevance of the deviation caused by the parametrisation.
-        Defined as the deviation relative to the cut-change.
-    """        
-    return (self.val_par - self.val_cut) / (self.val_cut - self.val_cut0) if abs(self.val_cut - self.val_cut0) > 0 else 0
-
-# ------------------------------------------------------------------------------
-
 class SingleCutTest:
   """ Class for everything needed to test a single cut value.
   """
@@ -94,13 +57,10 @@ class SingleCutTest:
     self.hist_cut_ptr = DH.get_hist_ptr(rdf_filtered, cut_distr_name, coords)
     self.hist_cut = None
     self.hist_par = None
-    self.dim = len(coords)
-
+    
     self.delta_c = delta_c # Cut values
     self.delta_w = delta_w
     
-    self.bin_tests = []
-
   def evaluate(self, coef_data, hist_nocuts):
     """ Evaluates the histograms of the test for both the actual cut and the
         parametrisation of the cut.
@@ -131,74 +91,7 @@ class SingleCutTest:
       # Scale the current bin 
       self.hist_par.SetBinContent(bin, factor*self.hist_par.GetBinContent(bin))
       i += 1 # Increment bin index without under/over-flow
-    
-  def prepare_bin_tests(self, hist_cut0, sig_scale):
-    """ Prepare the needed measures by creating bin tests for every histogram 
-        bin.
-        hist_cut0 -> Histogram for cut without edge varying
-        sig_scale -> Scale applied to histogram values to get a useful lumi
-    """
-    for bin in range(hist_cut0.GetNcells()):
-      # Skip overflow and underflow bins
-      if hist_cut0.IsBinUnderflow(bin) or hist_cut0.IsBinOverflow(bin): 
-          continue
-          
-      # Find the axis-specific bin indices
-      bin_xyz = [ctypes.c_int(0) for d in range(3)]
-      hist_cut0.GetBinXYZ(bin,bin_xyz[0],bin_xyz[1],bin_xyz[2])
-      bin_xyz = [int(bin_d.value) for bin_d in bin_xyz]
-          
-      # Find the bin center value for each axis
-      bin_center = []
-      bin_center.append(hist_cut0.GetXaxis().GetBinCenter(bin_xyz[0]))
-      if self.dim > 1: 
-        bin_center.append(hist_cut0.GetYaxis().GetBinCenter(bin_xyz[1]))
-      if self.dim > 2:
-        bin_center.append(hist_cut0.GetZaxis().GetBinCenter(bin_xyz[2]))
-        
-      # Find all relevant result values
-      val_cut = self.hist_cut.GetBinContent(bin) * sig_scale
-      val_par = self.hist_par.GetBinContent(bin) * sig_scale
-      val_cut0 = hist_cut0.GetBinContent(bin) * sig_scale
-      self.bin_tests.append(SingleBinTest(np.array(bin_center), val_cut, val_par, val_cut0))
-      
-    self.bin_tests = np.array(self.bin_tests)
-    
-  def get_axis_graphs(self, axis):
-    """ Get the validation graphs for the given axis.
-    """
-    # Collect all the measures together with the relevant axis coordinate
-    # (Use explicit double arrays that ROOT can understand)
-    x = array('d')
-    y_dev = array('d')
-    y_sig = array('d')
-    y_rel = array('d')
-    for bin_test in self.bin_tests:
-      x.append(bin_test.bin_center[axis])
-      y_dev.append(bin_test.relative_deviation())
-      y_sig.append(bin_test.deviation_significance())
-      y_rel.append(bin_test.deviation_relevance())
-    
-    # Create the graphs that test the mistake made by the parametrisation
-    base_name = self.hist_cut.GetName()
-    
-    graph_dev = ROOT.TGraph(len(self.bin_tests), x, y_dev)
-    graph_dev.SetName("{}_g_dev".format(base_name))
-    graph_sig = ROOT.TGraph(len(self.bin_tests), x, y_sig)
-    graph_sig.SetName("{}_g_sig".format(base_name))
-    graph_rel = ROOT.TGraph(len(self.bin_tests), x, y_rel)
-    graph_rel.SetName("{}_g_rel".format(base_name))
-    
-    return { "dev": graph_dev, "sig": graph_sig, "rel": graph_rel }
-    
-  def get_all_measures(self):
-    """ Get the arrays with all the values for the measures for all the bins.
-    """
-    return {
-      "dev": np.array([test.relative_deviation() for test in self.bin_tests]),
-      "sig": np.array([test.deviation_significance() for test in self.bin_tests]),
-      "rel": np.array([test.deviation_relevance() for test in self.bin_tests]) }
-      
+
 # ------------------------------------------------------------------------------
 
 class MuonAccValidator:
@@ -231,54 +124,17 @@ class MuonAccValidator:
         else:
           self.test_vals.append([dc*delta,dw*delta])
         
-    # Create the needed ROOT colors
-    self.colors = []
-    self.create_colors()
-    
     # Set up tests
     self.tests = [SingleCutTest(rdf, cut_val, delta_c, delta_w, costh_branch, distr_name, coords) for delta_c, delta_w in self.test_vals]
     self.histptr_nocut =  DH.get_hist_ptr(rdf, distr_name + "_nocut_val", coords)
 
-  def get_d_norm(self, dc, dw):
-    """ Get normalized root-of-squares sum of dc and dw.
-        Sign is not considered, only absolute deviation from 0.
+  def write_validation_data(self, coef_data, output, base_name, metadata, 
+                            n_total, cross_section):
+    """ Write the histogram data for all the validation histograms to the 
+        output directory.
     """
-    d_total = np.sqrt(dc**2+dw**2) / self.delta
-    return d_total/self.d_max
-
-  def get_color_index(self, dc, dw):
-    """ Translate the devation into a (custom) ROOT color index.
-    """
-    # Assume there are less than 100 distinct values
-    return 9000 + int(1000.0*self.get_d_norm(dc,dw))
-    
-  def create_colors(self):
-    """ Create all the necessary ROOT TColors.
-    """
-    colormap = cm.get_cmap("plasma") # Get a matplot lib color map
-    indices = []
-    for test_val in self.test_vals:
-      c_i = self.get_color_index(test_val[0],test_val[1])
-      if c_i in indices: 
-        continue # already created
-      else:
-        indices.append(c_i)
-      
-      d_norm = self.get_d_norm(test_val[0],test_val[1])
-      c_r, c_g, c_b, alpha = colormap(d_norm)
-      
-      c_name = "NewColor{}".format(c_i)
-      self.colors.append(ROOT.TColor(c_i, c_r, c_g, c_b, c_name))
-    
-  def validate(self, coef_data, sig_scale, output, base_name, extensions=["pdf","png","root"]):
-    """ Create plots to test the validity of the MuonAcceptance parametrisation 
-        and its coefficients.
-        Requires a "significance scale" which correctly scales the histograms
-        to some luminosity in order to meaningfully assess a significance of the
-        mistake made by the parametrisation.
-    """
-
     hist_nocuts = self.histptr_nocut.GetPtr()
+    dim = hist_nocuts.GetDimension()
       
     # Find the histogram that has the cut without deviations
     hist_0_arr = [test for test in self.tests if (test.delta_c == 0 and test.delta_w == 0)]
@@ -286,174 +142,86 @@ class MuonAccValidator:
       raise ValueError("Didn't find exactly one zero-cut array, found {}".format(len(hist_0_arr)))
     hist_0 = hist_0_arr[0].hist_cut_ptr.GetPtr()
     
-    # Evaluate all the tests
+    # Get the bin_indices without under/overflow bins:
+    bin_range = DH.get_bin_range(hist_nocuts)
+    n_bins = len(bin_range)
+    
+    # --- Determine the csv data for validation --------------------------------
+    
+    # Create the dictionary for the validation data
+    val_data = {
+      "Delta-c" : [],
+      "Delta-w" : []
+    }
+    for i_bin in range(n_bins):
+      val_data["C{}".format(i_bin)] = [] # Value with true cut
+      val_data["P{}".format(i_bin)] = [] # Value from parametrisation
+    
+    # Get the data from all the tested histograms
     for test in self.tests:
+      # Evaluate the test histograms
       test.evaluate(coef_data, hist_nocuts)
-      test.prepare_bin_tests(hist_0, sig_scale)
       
-    # --------------------------------------------------------------------------
-    # Plotting of deviations for each axis
-
-    for d in range(len(self.coords)):
-      coord_name = self.coords[d].name
-
-      # Create the stacks for the result checks
-      stack_name_base = "{}_{}".format(base_name, coord_name)
-      stack_name_dev = "{}_dev".format(stack_name_base)
-      stack_name_sig = "{}_sig".format(stack_name_base)
-      stack_name_rel = "{}_rel".format(stack_name_base)
+      # Save the tested values
+      val_data["Delta-c"] = test.delta_c
+      val_data["Delta-w"] = test.delta_w
       
-      stack_dev = ROOT.TMultiGraph(stack_name_dev, stack_name_dev)
-      stack_sig = ROOT.TMultiGraph(stack_name_sig, stack_name_sig)
-      stack_rel = ROOT.TMultiGraph(stack_name_rel, stack_name_rel)
+      # Get all the bin values from the histogram
+      for i_bin in range(n_bins):
+        bin = bin_range[i_bin] # Histogram-internal bin index
+        val_data["C{}".format(i_bin)].append(test.hist_cut.GetBinContent(bin) ) # Value with true cut
+        val_data["P{}".format(i_bin)].append(test.hist_par.GetBinContent(bin) ) # Value from parametrisation
+      
+    # Create a pandas dataframe
+    df = pd.DataFrame(val_data)
+
+    # Write the dataframe to a csv file
+    val_subdir = "{}/validation".format(output.dir)
+    OH.create_dir(val_subdir)
+    file_path = "{}/{}_valdata.csv".format(val_subdir,base_name)
+    df.to_csv(file_path)
+
+    # --- Determine all the needed metadata ------------------------------------
     
-      # Get all the individual graphs for the different checked cut points
-      for test in self.tests:
-        test_graphs = test.get_axis_graphs(d)
-        graph_dev = test_graphs["dev"]
-        graph_sig = test_graphs["sig"]
-        graph_rel = test_graphs["rel"]
-        
-        color = self.get_color_index(test.delta_c,test.delta_w)
-        graph_dev.SetMarkerColor(color)
-        graph_sig.SetMarkerColor(color)
-        graph_rel.SetMarkerColor(color)
-        
-        stack_dev.Add(graph_dev)
-        stack_sig.Add(graph_sig)
-        stack_rel.Add(graph_rel)
-        
-      # Draw and save the stacks
-      canvas_dev = ROOT.TCanvas("c_{}".format(stack_name_dev))
-      canvas_dev.cd()
-      stack_dev.Draw("AP")
-      stack_dev.GetXaxis().SetTitle(coord_name)
-      stack_dev.GetYaxis().SetTitle("(N_{param}-N_{cut})/N_{cut}")
-      
-      canvas_sig = ROOT.TCanvas("c_{}".format(stack_name_sig))
-      canvas_sig.cd()
-      stack_sig.Draw("AP")
-      stack_sig.GetXaxis().SetTitle(coord_name)
-      stack_sig.GetYaxis().SetTitle("|N_{param}-N_{cut}|/#sqrt{N_{cut}}")
-      
-      canvas_rel = ROOT.TCanvas("c_{}".format(stack_name_rel))
-      canvas_rel.cd()
-      stack_rel.Draw("AP")
-      stack_rel.GetXaxis().SetTitle(coord_name)
-      stack_rel.GetYaxis().SetTitle("(N_{param}-N_{cut})/(N_{cut}-N_{cut,0})")
-      
-      for extension in extensions:
-        # Create the plot subdirectory
-        plot_subdir = "{}/plots/{}".format(output.dir,extension)
-        OH.create_dir(plot_subdir)
-        
-        # Save the histograms
-        canvas_dev.Print("{}/{}.{}".format(plot_subdir, stack_name_dev, extension))
-        canvas_sig.Print("{}/{}.{}".format(plot_subdir, stack_name_sig, extension))
-        canvas_rel.Print("{}/{}.{}".format(plot_subdir, stack_name_rel, extension))
-        
-    # --------------------------------------------------------------------------
-    # Plotting of overall distribution of deviations  
-        
-    # Arrays to track 1D distribution of deviations depending on the test radius
-    r_steps = [ 0.0, 0.75, 1.5, 3.0, 5.5]
-    r_colors = [self.get_color_index(r*self.delta,0) for r in [0.5, np.sqrt(2), 2.5, 5]]
-    vals_sig = [[] for r in range(len(r_steps)-1)] # deviation-significance
-    vals_rel = [[] for r in range(len(r_steps)-1)] # deviation-relevance
-
-    # Collect and correctly sort the validation measure values of all bins
-    for test in self.tests:
-      # Find the right radius-index to store the deviations in
-      i_r = None
-      d_tot = self.get_d_norm(test.delta_c, test.delta_w) * self.d_max
-      for s in range(len(r_steps)-1):
-        if (d_tot >= r_steps[s]) and (d_tot < r_steps[s+1]):
-          i_r = s
-          break
-      
-      # Collect all the validation measures
-      # -> Skip 0-values, happen only if no cut influence or no deviation from 
-      #    cut-change
-      test_dict = test.get_all_measures()
-      for sig in test_dict["sig"]:
-        if sig != 0:
-          vals_sig[i_r].append(sig)
-        
-      for rel in test_dict["rel"]:
-        if rel != 0:
-          vals_rel[i_r].append(rel)
+    # Get the coordinate infos
+    coord_names = [coord.name for coord in self.coords]
+    coord_nbins = [coord.n_bins for coord in self.coords]
+    coord_mins = [coord.min for coord in self.coords]
+    coord_maxs = [coord.max for coord in self.coords]
+    
+    # Get the data for the histogram without any cut
+    nocut_data = [hist_nocuts.GetBinContent(bin) for bin in bin_range]
+    
+    # Determine the bin centers
+    bin_centers = []
+    for bin in bin_range:
+      # Find the axis-specific bin indices
+      bin_xyz = [ctypes.c_int(0) for d in range(3)]
+      hist_0.GetBinXYZ(bin,bin_xyz[0],bin_xyz[1],bin_xyz[2])
+      bin_xyz = [int(bin_d.value) for bin_d in bin_xyz]
           
-    # Create a stacks for the 1D histograms of the deviation
-    stack_name_rel = "{}_rel".format(base_name)
-    stack_name_sig = "{}_sig".format(base_name)
-    
-    stack_rel_1D = ROOT.THStack(stack_name_rel, stack_name_rel)
-    legend_rel_1D = ROOT.TLegend(0.2,0.4,0.5,0.9)
-    legend_rel_1D.SetHeader("Test val. in #Delta = {}".format(self.delta))
-    
-    stack_sig_1D = ROOT.THStack(stack_name_sig, stack_name_sig)
-    legend_sig_1D = ROOT.TLegend(0.5,0.4,0.9,0.9)
-    legend_sig_1D.SetHeader("Test val. in #Delta = {}".format(self.delta))
-    
-    # Plot the deviation-relevance distribution for each step in test-radius
-    for s in range(len(r_steps)-1):
-      r_min = r_steps[s]
-      r_max = r_steps[s+1]
-      step_label = "{} - {}".format(r_min, r_max)
-      
-      # Create the deviation histograms for this radius range
-      hist_name_rel = stack_name_rel + "_" + str(r_min) + "_" + str(r_max)
-      new_hist_rel = ROOT.TH1D(hist_name_rel,hist_name_rel,51,-2.5,2.5)
-      
-      hist_name_sig = stack_name_sig + "_" + str(r_min) + "_" + str(r_max)
-      new_hist_sig = ROOT.TH1D(hist_name_sig,hist_name_sig,60,0.0,1.5)
-      
-      # Fill the deviation histograms
-      for val_rel in vals_rel[s]: new_hist_rel.Fill(val_rel)
-      for val_sig in vals_sig[s]: new_hist_sig.Fill(val_sig)
-        
-      # Normalise
-      if new_hist_rel.Integral() > 0: new_hist_rel.Scale(1.0/new_hist_rel.Integral()) 
-      if new_hist_sig.Integral() > 0: new_hist_sig.Scale(1.0/new_hist_sig.Integral()) 
-        
-      # Plotting 
-      new_hist_rel.SetLineColor(r_colors[s])
-      stack_rel_1D.Add(new_hist_rel, "hist")
-      legend_rel_1D.AddEntry(new_hist_rel, step_label)
-      
-      new_hist_sig.SetLineColor(r_colors[s])
-      stack_sig_1D.Add(new_hist_sig, "hist")
-      legend_sig_1D.AddEntry(new_hist_sig, step_label)
-    
-    # Plot the 1D deviation distributions
-    canvas_rel_1D = ROOT.TCanvas("c_{}".format(stack_name_rel))
-    canvas_rel_1D.cd()
-    stack_rel_1D.Draw("nostack")
-    stack_rel_1D.GetXaxis().SetTitle("(N_{param}-N_{cut})/(N_{cut}-N_{cut,0})")
-    stack_rel_1D.GetYaxis().SetTitle("a.u.")
-    stack_rel_1D.SetMinimum(0.0)
-    stack_rel_1D.SetMaximum(1.0)
-    legend_rel_1D.Draw()
-    legend_rel_1D.SetFillStyle(0) # Transparent legend-background
-    
-    canvas_sig_1D = ROOT.TCanvas("c_{}".format(stack_name_sig))
-    canvas_sig_1D.cd()
-    stack_sig_1D.Draw("nostack")
-    stack_sig_1D.GetXaxis().SetTitle("|N_{param}-N_{cut}|/#sqrt{N_{cut}}")
-    stack_sig_1D.GetYaxis().SetTitle("a.u.")
-    stack_sig_1D.SetMinimum(0.0)
-    stack_sig_1D.SetMaximum(1.0)
-    legend_sig_1D.Draw()
-    legend_sig_1D.SetFillStyle(0) # Transparent legend-background
-    
-    # Save the histogram
-    for extension in extensions:
-      # Create the plot subdirectory
-      plot_subdir = "{}/plots/{}".format(output.dir,extension)
-      OH.create_dir(plot_subdir)
-      
-      # Save the histograms
-      canvas_rel_1D.Print("{}/{}.{}".format(plot_subdir, stack_name_rel, extension))
-      canvas_sig_1D.Print("{}/{}.{}".format(plot_subdir, stack_name_sig, extension))
+      # Find the bin center value for each axis
+      bin_center = [hist_0.GetXaxis().GetBinCenter(bin_xyz[0])]
+      if dim > 1: 
+        bin_center.append(hist_0.GetYaxis().GetBinCenter(bin_xyz[1]))
+      if dim > 2:
+        bin_center.append(hist_0.GetYaxis().GetBinCenter(bin_xyz[2]))
+      bin_centers.append(bin_center)
+
+    # Attach metadata to beginning of file
+    val_metadata = CSVM.CSVMetadata()
+    val_metadata.metadata = metadata.metadata.copy()
+    val_metadata["NTotalMC"] = n_total
+    val_metadata["CrossSection"] = cross_section
+    val_metadata["CoordName"] = coord_names
+    val_metadata["CoordNBins"] = coord_nbins
+    val_metadata["CoordMin"] = coord_mins
+    val_metadata["CoordMax"] = coord_maxs
+    val_metadata["BinCenters"] = bin_centers
+    val_metadata["NoCutData"] = nocut_data
+    val_metadata["Delta"] = self.delta
+
+    # Attach the metadata to the data file
+    val_metadata.write(file_path)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Move csv file naming convention to separate python module.
- Add default delta function for calculation muon acceptance parametrisation coefficients.
- Fix bug in MuonAcceptance.
- Add first 1D muon parametrisation validation test python code and use it when creating the relevant samples.
- Add coloring to muon acceptance validation.
- Change the calculation of the muon acceptance coefficients to one testing more sensible and better distributed points.
- Add a second significance-based measure to assess the validity of the parametrisation for the muon acceptance.
- Correct the definition of the width parameter in the muon acceptance calculation.
- Use TGraph in muon acceptance validation to also assess sign of mistake made by parametrisation.
- Restrict tests for the muon acceptance validation to deviations within a reasonable range.
- Change definition of relative mistake approach in systematics validation for muon acceptance.
- Use a fit to more cut points to get a more accurate result for the coefficients of the muon acceptance parametrisation.
- Improve visualisation in validation of muon acceptance systematic by using different color map and grouping deviations in more sensible way.
- Plot the effect of the central muon acceptance cut in the muon acceptance calculator.
- Restrict tested deviation values in the muon acceptance calculation to avoid too much weight on outer points.
- Add plot of deviation relevance to muon acceptance validation.
- Adjust the uncertainties used in the parametrisation fit for the muon acceptance to allow for a reasonable fit.
- Add 1D deviation plots to muon acceptance parametrisation validation.
- Enable muon acceptance validation on 3D histograms.
- Simplify the CSVMetadata class by adding item operators and removing the restricting metadata list.
- Move from plotting the muon validation plots inside the sample creation to saving the relevant histograms to perform the validation plotting on.
- Fix bug in muon acceptance validation.
- Fix another bug in muon acceptance validation.
- Change to a more convenient test range in muon acceptance validation.
- Refactor coefficient fit for muon acceptance and introduce check for situations that don't require fit.
- Switch muon acceptance to 7deg.