### PR TITLE
Remove RK TGC coefficients

### DIFF
--- a/PrEWInputProduction/Core/CreatePrEWInput.py
+++ b/PrEWInputProduction/Core/CreatePrEWInput.py
@@ -14,8 +14,6 @@ import sys
 import Conventions as Conv
 sys.path.append("../IO")
 import CSVMetadata as CSVM
-sys.path.append("../RKHelp")
-import RKCoefMatcher as RKCM
 sys.path.append("../ROOTHelp")
 import DistrHelpers as DH
 import DistrPlotting as DP
@@ -99,10 +97,6 @@ def create_PrEW_input(input, output, coords, cuts,
 
   # Extract bin centers and cross sections from the histogram
   data = DH.get_data(hist, coords)
-
-  # Try to find coefficients from RK distribution
-  coef_matcher = RKCM.default_coef_matcher()
-  data = coef_matcher.add_coefs_to_data(output.distr_name, eM_chi, eP_chi, data)
 
   # Try extracting the differential coefficients for the muon acceptance box.
   if muon_acc is not None:

--- a/PrEWInputProduction/SingleW/SingleW.py
+++ b/PrEWInputProduction/SingleW/SingleW.py
@@ -42,9 +42,9 @@ def main():
 
     # Coordinates
     coords = [
-        DH.Coordinate("costh_Whad_star", 20, -0.9695290858725761, 0.9695290858725761),
-        DH.Coordinate("costh_e_star", 10, -0.925925925925926, 0.925925925925926),
-        DH.Coordinate("m_enu", 20, 4.037857055, 165.55213928499998),
+        DH.Coordinate("costh_Whad_star", 20, -1.0, 1.0),
+        DH.Coordinate("costh_e_star", 10, -1.0, 1.0),
+        DH.Coordinate("m_enu", 20, 0.0, 240.0) # in Data min and max are 0.118263 and 238.599915 
     ]
 
     # Create distributions for opposite-sign chiralities (both charges)

--- a/PrEWInputProduction/WW/WW.py
+++ b/PrEWInputProduction/WW/WW.py
@@ -38,8 +38,8 @@ def main():
 
     # Coordinates
     coords = [
-        DH.Coordinate("costh_Wminus_star", 20, -0.9695290858725761, 0.9695290858725761),
-        DH.Coordinate("costh_l_star", 10, -0.925925925925926, 0.925925925925926),
+        DH.Coordinate("costh_Wminus_star", 20, -1.0, 1.0),
+        DH.Coordinate("costh_l_star", 10, -1.0, 1.0),
         DH.Coordinate("phi_l_star", 10, -math.pi, math.pi),
     ]
 


### PR DESCRIPTION
- Remove the coefficient matching of the TGC coefficients provided by Roberts O'Mega code (approach found to be invalid).
- Remove cuts from 4f coordinates that were necessary to match the now deprecated RK TGC coefficients.