### PR TITLE
Split 2f return-to-Z into forward and backward

### DIFF
--- a/PrEWInputProduction/Difermion/DifermionLeptonic.py
+++ b/PrEWInputProduction/Difermion/DifermionLeptonic.py
@@ -43,32 +43,52 @@ def main():
         DH.Coordinate("costh_f_star", 20, -1.0, 1.0)
     ]
 
-    # Mass ranges 
-    mass_cuts = [
-      [81, 101],
-      [180, 1.1*energy]
-    ]
+    # Mass cut ranges and FB cut for return-to-Z
+    mass_cuts = {
+      "return-to-Z" : [81, 101],
+      "high-Q2" : [180, 1.1*energy]
+    }
+    
+    # for m_low, m_high in mass_cuts:
+    cut_dict = {}
+    for mass_range_name, cut_value in mass_cuts.items():
+      m_low, m_high = cut_value
+      mass_cut_name = "{}to{}".format(int(m_low),int(m_high))
+      mass_cut = "(m_ff > {}) && (m_ff < {})".format(m_low, m_high)
+      
+      if mass_range_name == "return-to-Z":
+        # For return-to-Z with string ISR, split forward and backward Pz_ff
+        forward_cut_name = "{}_FZ".format(mass_cut_name)
+        backward_cut_name = "{}_BZ".format(mass_cut_name)
+        forward_cut = "{} && (pz_ff > 0)".format(mass_cut)
+        backward_cut = "{} && (pz_ff < 0)".format(mass_cut)
+        cut_dict[forward_cut_name] = forward_cut
+        cut_dict[backward_cut_name] = backward_cut
+      else:
+        # For high-Q^2 no further splitting
+        cut_dict[mass_cut_name] = mass_cut
+      
     
     # --- Muons (w/ systematics) ------------------------------------------------
     for input in inputs:
-      for m_low, m_high in mass_cuts:
-        distr_name = "2f_mu_{}to{}".format(int(m_low),int(m_high))
-        cuts = "(f_pdg == 13) && (m_ff > {}) && (m_ff < {})".format(m_low,m_high)
+      for cut_name, cuts in cut_dict.items():
+        distr_name = "2f_mu_{}".format(cut_name)
+        distr_cuts = "(f_pdg == 13) && {}".format(cuts)
         CPI.create_PrEW_input(
           input = input, coords = coords, 
           output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
-          cuts = cuts, 
+          cuts = distr_cuts, 
           syst = SSO.SystematicsOptions(use_muon_acc=True,costh_branch=["costh_f","costh_fbar"]))
-        
+      
     # --- Taus (no systematics) ------------------------------------------------
     for input in inputs:
-      for m_low, m_high in mass_cuts:
-        distr_name = "2f_tau_{}to{}".format(int(m_low),int(m_high))
-        cuts = "(f_pdg == 15) && (m_ff > {}) && (m_ff < {})".format(m_low,m_high)
+      for cut_name, cuts in cut_dict.items():
+        distr_name = "2f_tau_{}".format(cut_name)
+        distr_cuts = "(f_pdg == 15) && {}".format(cuts)
         CPI.create_PrEW_input(
           input = input, coords = coords, 
           output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
-          cuts = cuts)
+          cuts = distr_cuts)
     
     print("Done.")
 

--- a/source/include/Difermion/DifermionObservables.h
+++ b/source/include/Difermion/DifermionObservables.h
@@ -19,6 +19,7 @@ struct DifermionObservables {
   double costh_f{};
   double costh_fbar{};
   double m_ff{};
+  double pz_ff{};
 
   void reset() {
     /** Reset all observables to their default value.
@@ -26,6 +27,7 @@ struct DifermionObservables {
     f_pdg = 0;
     costh_f_star = 9e9;
     m_ff = 9e9;
+    pz_ff = 9e9;
     costh_f = 9e9;
     costh_fbar = 9e9;
   }

--- a/source/src/Difermion/Processor/create_tree.cpp
+++ b/source/src/Difermion/Processor/create_tree.cpp
@@ -17,6 +17,7 @@ void DifermionProcessor::create_tree() {
   m_tree->Branch("f_pdg", &m_observables.f_pdg, "f_pdg/I");
   m_tree->Branch("costh_f_star", &m_observables.costh_f_star, "costh_f_star/D");
   m_tree->Branch("m_ff", &m_observables.m_ff, "m_ff/D");
+  m_tree->Branch("pz_ff", &m_observables.pz_ff, "pz_ff/D");
   m_tree->Branch("costh_f", &m_observables.costh_f, "costh_f/D");
   m_tree->Branch("costh_fbar", &m_observables.costh_fbar, "costh_fbar/D");
 }

--- a/source/src/Difermion/Processor/extract_lab_observables.cpp
+++ b/source/src/Difermion/Processor/extract_lab_observables.cpp
@@ -14,5 +14,6 @@ void DifermionProcessor::extract_lab_observables(
   m_observables.costh_f = f_tlv_lab.CosTheta();
   m_observables.costh_fbar = fbar_tlv_lab.CosTheta();
   m_observables.m_ff = ffbar_tlv_lab.M();
+  m_observables.pz_ff = ffbar_tlv_lab.Pz();
   // ---------------------------------------------------------------------------
 }


### PR DESCRIPTION
- Add Pz_ff observable in 2f processor to allow splitting forward and backward events.
- Split 2f_z_l PrEW input return-to-Z into Forward and Backward Z (due to ISR) in the DifermionLeptonic python script.

