### PR TITLE
Add true 2f cos theta star information

### DIFF
--- a/PrEWInputProduction/Difermion/DifermionLeptonic.py
+++ b/PrEWInputProduction/Difermion/DifermionLeptonic.py
@@ -89,6 +89,19 @@ def main():
           input = input, coords = coords, 
           output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = create_plots), 
           cuts = distr_cuts)
+          
+    # --- Muons with true angle and no systematics -----------------------------
+    output_dir = "/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/NewMCProduction/2f_Z_l/PrEWInput/TrueAngle"
+    coords = [ DH.Coordinate("costh_f_star_true", 20, -1.0, 1.0) ]
+
+    for input in inputs:
+      for cut_name, cuts in cut_dict.items():
+        distr_name = "2f_mu_{}_true".format(cut_name)
+        distr_cuts = "(f_pdg == 13) && {}".format(cuts)
+        CPI.create_PrEW_input(
+          input = input, coords = coords, 
+          output = OH.OutputInfo( output_dir, distr_name = distr_name, create_plots = False), 
+          cuts = distr_cuts)      
     
     print("Done.")
 

--- a/macros/SubmitScripts/submit_script.submit
+++ b/macros/SubmitScripts/submit_script.submit
@@ -13,4 +13,7 @@ log                 = $(log_dir)/$(Cluster).$(Process).log
 # for each job. Remember that regular filesystem rules about maximum files in a directory and maximum filesizes apply (warning)
 # htcondor will (as any other batchsystem) not create any directories for you, hence these need to exist.
 
+# Specify the operating system
+Requirements = ( OpSysAndVer == "CentOS7" ) 
+
 queue

--- a/source/include/Difermion/DifermionObservables.h
+++ b/source/include/Difermion/DifermionObservables.h
@@ -11,9 +11,12 @@ struct DifermionObservables {
   // Boost-independent observables
   int f_pdg{};
 
-  // Observables in the ee rest frame
+  // Observables in the ffbar rest frame
   // -> Detector coordinate system (expecting no significant x-y boost)
   double costh_f_star{};
+  
+  // Observables in cheated ffbar frame assuming ISR to be known exactly
+  double costh_f_star_true{};
 
   // Observables in detector rest frame
   double costh_f{};
@@ -26,6 +29,7 @@ struct DifermionObservables {
      **/
     f_pdg = 0;
     costh_f_star = 9e9;
+    costh_f_star_true = 9e9;
     m_ff = 9e9;
     pz_ff = 9e9;
     costh_f = 9e9;

--- a/source/include/Difermion/DifermionProcessor.h
+++ b/source/include/Difermion/DifermionProcessor.h
@@ -99,6 +99,10 @@ private:
                                const EVENT::MCParticle &fbar);
   void extract_ff_observables(const EVENT::MCParticle &f,
                               const EVENT::MCParticle &fbar);
+  void extract_ff_true_observables(const EVENT::MCParticle &f,
+                                   const EVENT::MCParticle &fbar,
+                                   const EVENT::MCParticle &eM_after_ISR,
+                                   const EVENT::MCParticle &eP_after_ISR);
 };
 
 #endif

--- a/source/src/Difermion/Processor/create_tree.cpp
+++ b/source/src/Difermion/Processor/create_tree.cpp
@@ -16,6 +16,7 @@ void DifermionProcessor::create_tree() {
   // Create and connect the observable branches
   m_tree->Branch("f_pdg", &m_observables.f_pdg, "f_pdg/I");
   m_tree->Branch("costh_f_star", &m_observables.costh_f_star, "costh_f_star/D");
+  m_tree->Branch("costh_f_star_true", &m_observables.costh_f_star_true, "costh_f_star_true/D");
   m_tree->Branch("m_ff", &m_observables.m_ff, "m_ff/D");
   m_tree->Branch("pz_ff", &m_observables.pz_ff, "pz_ff/D");
   m_tree->Branch("costh_f", &m_observables.costh_f, "costh_f/D");

--- a/source/src/Difermion/Processor/extract_ff_true_observables.cpp
+++ b/source/src/Difermion/Processor/extract_ff_true_observables.cpp
@@ -1,0 +1,32 @@
+#include <Difermion/DifermionProcessor.h>
+#include <Utils/MC.h>
+
+// includes from MarlinHelp
+#include <MarlinHelp/Root/LorentzVec.h>
+
+void DifermionProcessor::extract_ff_true_observables(
+    const EVENT::MCParticle &f, const EVENT::MCParticle &fbar,
+    const EVENT::MCParticle &eM_after_ISR,
+    const EVENT::MCParticle & /*eP_after_ISR*/) {
+  /** Extract the observables in the cheated ffbar frame where it is assumed
+   *that ISR of both e+ and e- are exactly known.
+   **/
+  // Lorentz vectors in lab frame
+  auto f_tlv_lab = Utils::MC::get_tlv(f);
+  auto fbar_tlv_lab = Utils::MC::get_tlv(fbar);
+  auto eM_ISR_tlv_lab = Utils::MC::get_tlv(eM_after_ISR);
+  // auto eP_ISR_tlv_lab = Utils::MC::get_tlv(eP_after_ISR);
+
+  auto ffbar_tlv_lab = f_tlv_lab + fbar_tlv_lab;
+
+  // Boost into ff frame
+  auto f_tlv_ff =
+      MarlinHelp::Root::LorentzVec::boost_tlv(f_tlv_lab, ffbar_tlv_lab);
+  auto eM_ISR_tlv_ff =
+      MarlinHelp::Root::LorentzVec::boost_tlv(eM_ISR_tlv_lab, ffbar_tlv_lab);
+
+  // --- Find observables ------------------------------------------------------
+  m_observables.costh_f_star_true =
+      MarlinHelp::Root::LorentzVec::cos_theta(f_tlv_ff, eM_ISR_tlv_ff);
+  // ---------------------------------------------------------------------------
+}

--- a/source/src/Difermion/Processor/extract_observables.cpp
+++ b/source/src/Difermion/Processor/extract_observables.cpp
@@ -36,4 +36,9 @@ void DifermionProcessor::extract_observables(const EVENT::MCParticleVec &mcps) {
 
   // Extract observables in ffbar rest frame
   this->extract_ff_observables(*f, *fbar);
+
+  // --- Observables using truth level information that can't be reconstructed
+  auto eM_after_ISR = Utils::MC::incoming_eM_after_ISR(mcps);
+  auto eP_after_ISR = Utils::MC::incoming_eP_after_ISR(mcps);
+  this->extract_ff_true_observables(*f, *fbar, *eM_after_ISR, *eP_after_ISR);
 }


### PR DESCRIPTION
- Explicitly set the OS in the HTCondor submit script.
- Add the true (after ISR) cosThetaStar angle in the difermion processor.
- Create 2f leptonic true angle csv file distributions in the python script.

